### PR TITLE
v0.9.3: Alt+F filter, Alt+S sort popup, mouse control, smart config merge & auto-restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Build output
+build/
+*.o
+*.a
+*.so
+*.so.*
+*.dylib
+
+# CMake generated
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+Makefile
+config.h
+config.h.bak
+
+# Autoconf generated
+autom4te.cache/
+configure
+aclocal.m4
+config.log
+config.status
+config.guess
+config.sub
+libtool
+ltmain.sh
+stamp-h1
+*.in.bak
+
+# Editor backup / temp files
+*~
+*.swp
+*.swo
+*.orig
+*.bak
+\#*\#
+.#*
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# IDE / tools
+.vscode/
+.idea/
+*.cbp.bak
+*.user
+compile_commands.json
+
+# Packaging
+*.deb
+*.rpm
+*.tar.gz
+*.tar.bz2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project (linm)
 
 set(PACKAGE "linm")
-set(VERSION "0.9.1")
+set(VERSION "0.9.3")
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wp,-w")
@@ -197,7 +197,7 @@ endif()
 
 ########### set configure file
 
-option(LINM_CFGPATH "set configure file install path. (default: '${CMAKE_INSTALL_PREFIX}/etc/linm')")
+set(LINM_CFGPATH "" CACHE STRING "set configure file install path. (default: '${CMAKE_INSTALL_PREFIX}/etc/linm')")
 
 if(LINM_CFGPATH)
     set(__LINM_CFGPATH__ "${LINM_CFGPATH}")
@@ -209,15 +209,15 @@ message( STATUS "Option - configure path : '${__LINM_CFGPATH__}'" )
 
 ########### set bin path
 
-option(LINM_BINPATH "set binary file install path. (default: '${CMAKE_INSTALL_PREFIX}/bin/linm')")
+set(LINM_BINPATH "" CACHE STRING "set binary file install path. (default: '${CMAKE_INSTALL_PREFIX}/bin')")
 
 if(LINM_BINPATH)
     set(__LINM_BINPATH__ "${LINM_BINPATH}")
 else()
-    set(__LINM_BINPATH__ "${CMAKE_INSTALL_PREFIX}/bin/linm")
+    set(__LINM_BINPATH__ "${CMAKE_INSTALL_PREFIX}/bin")
 endif(LINM_BINPATH)
 
-message( STATUS "Option - configure path : '${__LINM_CFGPATH__}'" )
+message( STATUS "Option - binary path : '${__LINM_BINPATH__}'" )
 
 ########### set debug mode
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project (linm)
 
 set(PACKAGE "linm")
-set(VERSION "0.9.3")
+set(VERSION "0.9.4")
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wp,-w")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project (linm)
 
 set(PACKAGE "linm")
-set(VERSION "0.9.4")
+set(VERSION "0.9.5")
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wp,-w")

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2026-03-15 Bill,Kang <zirize@gmail.com>
+	- 보안 업데이트: sprintf → snprintf (mainframe.cpp, SMBReader.cpp),
+	  strcpy → memcpy (mlslocale.cpp), system() 호출 경로 인수 shell 인용부호 처리.
+	- touch 파일 생성 명령을 system("touch ...") 대신 open() syscall로 교체하여
+	  shell injection 방지.
+	- ShellQuotePath() 헬퍼 추가: system() 명령에 사용되는 경로를 single quote로
+	  감싸 특수문자가 포함된 경로에서도 안전하게 동작.
+	- Alt+F 필터를 정규표현식(regex) 기반으로 변경: 대소문자 구분 없는 regex 검색,
+	  잘못된 regex 패턴일 경우 substring 검색으로 자동 폴백.
+	- 필터 표시줄에 regex 유효 여부 표시: [F/RE:...] (유효한 regex),
+	  [F/?:...] (무효한 regex - substring 검색 중).
+
 2026-03-14 Bill,Kang <zirize@gmail.com>
 	- Alt+F로 파일 이름 필터 기능 추가 (실시간 파일 목록 필터링, 디렉토리 제외).
 	- 필터 상태가 디렉토리 이동 시에도 유지되도록 개선.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,23 @@
+2026-03-14 Bill,Kang <zirize@gmail.com>
+	- Alt+F로 파일 이름 필터 기능 추가 (실시간 파일 목록 필터링, 디렉토리 제외).
+	- 필터 상태가 디렉토리 이동 시에도 유지되도록 개선.
+	- Alt+S로 정렬 방식을 팝업 메뉴에서 선택 가능하도록 개선.
+	- --nomouse / -M 옵션 및 LINM_NO_MOUSE 환경변수로 마우스 비활성화 기능 추가.
+	- default.cfg에 Mouse = On/Off 옵션 추가 (설정 파일로 마우스 제어).
+	- F1 도움말 시스템 재정리: 논리적 그룹 구분, 표시 순서 보장, 누락 항목 추가.
+	- Ctrl+D 키를 Cmd_Remove(삭제)에서 제거, Cmd_Quit 전용으로 변경.
+	- 버전 업 시 설정 파일 스마트 병합: Yes/No 다이얼로그 대신 자동 병합
+	  (기존 설정 유지, 신규 키만 추가), 병합 후 execvp로 재시작하여 설정 완전 반영.
+	- Configure::MergeFromFile() 추가: 시스템 기본 cfg에서 누락 키만 user cfg에 병합.
+	- default/keyset/colorset/syntexset 4개 cfg 버전을 개별 체크하여
+	  하나라도 버전 불일치 시 병합 루틴 발동.
+	- 0.9.3 으로 버전 올림.
+	- 기본 설정 디렉토리를 .linm 에서 .config/linm 으로 변경.
+	- LastPath 경로가 유효하지 않을 경우 segfault 나는 문제 수정.
+	- 설정 파일의 버전이 일치하지 않을 때 반복적으로 복사를 묻는 문제 수정.
+	- CMake 옵션(LINM_CFGPATH, LINM_BINPATH)이 정상적으로 작동하도록 수정.
+	- 0.9.2 로 버전 올림.
+
 2008-05-26 Byoungyoung,La <la9527@daum.net>
   - 커맨드에서 탭 입력시 디렉토리 끝에 '/' 들어가게 반영
   
@@ -160,7 +180,7 @@
 2006-01-21 라병영 <la9527@daum.net>
 	- sftp, ftp 복사시 한글일 경우 EUC-KR, UTF8 복사를 물어보게 수정.
 	- sftp, ftp에서 Editor로 이용하여 파일 저장시 파일이 자동으로 sftp, ftp로 저장되게 수정.
-	- tmp 디렉토리를 ~/.linm/linmtmp_dir 로 바꾸고 tmp에 파일 지워짖 않은 버그 수정.
+	- tmp 디렉토리를 ~/.config/linm/linmtmp_dir 로 바꾸고 tmp에 파일 지워짖 않은 버그 수정.
 	- cygwin 의 키코드 다른 문제 수정.
 
 2006-01-19 라병영 <la9527@daum.net>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-03-20 Bill,Kang <zirize@gmail.com>
+	- 이동식 드라이브 등 마지막 접속 경로(LastPath)가 더 이상 존재하지 않을 경우
+	  오류 없이 홈 디렉토리로 자동 fallback하여 시작하도록 개선.
+	- 현재 작업 디렉토리(cwd)가 삭제된 상태에서 실행 시에도 안전하게 시작.
+	- LastPath fallback 성공 시 설정 파일에 유효한 경로를 자동 저장.
+	- DirReader::GetCurrentPath()에서 getpwuid() 반환값이 NULL일 때 발생하는
+	  NULL 포인터 역참조(segfault) 수정.
+	- Panel::Init()에서 _bFilterRegexValid 초기화 누락 수정 (undefined behavior 방지).
+	- 0.9.5 로 버전 올림.
+
 2026-03-15 Bill,Kang <zirize@gmail.com>
 	- 보안 업데이트: sprintf → snprintf (mainframe.cpp, SMBReader.cpp),
 	  strcpy → memcpy (mlslocale.cpp), system() 호출 경로 인수 shell 인용부호 처리.

--- a/README
+++ b/README
@@ -48,8 +48,7 @@
    1) default.cfg, coloset.cfg, keyset.cfg
       
       Linm configuration files. 
-      Under /etc/linm if installed by root; otherwise, under $HOME/.linm.
-         
+      Under /etc/linm if installed by root; otherwise, under $HOME/.config/linm.         
    2) linm.sh, linm_aliase.sh   	
           
       LinM executable and shell scripts to move 

--- a/README.ko
+++ b/README.ko
@@ -8,7 +8,7 @@ MS-DOS 시절 유명했던 Mdir의 리눅스 클론으로, Mdir의 단축키와 
 파일 복사/이동/삭제, 디렉토리 트리 탐색, 파일 검색, 서브쉘 실행을 비롯해 FTP/SFTP, tar/zip/alz 아카이브 보기, RPM/DEB 패키지 탐색 등 다양한 기능을 제공합니다.
 
 - 오리지널 프로젝트: https://github.com/la9527/linm
-- 버그 리포트 및 문의: la9527@daum.net
+- 버그 리포트 및 문의: zirize@gmail.com (fork) / la9527@daum.net (original)
 
 ---
 

--- a/README.ko
+++ b/README.ko
@@ -1,552 +1,209 @@
+# LinM
 
-* LinM
+## 소개
 
-  LinM 은 도스용 파일관리 툴인 Mdir의 리눅스 클론 입니다.
-  기존 Mdir의 단축키와 화면구성 등을 비슷하게 하여 친숙하게 사용할 수 있게 만든 프로그램입니다.
-   
-  프로그램의 기능 버그, 추가될 사항이 있으시면 프로젝트 
-  홈페이지나, 이메일을 통해서 연락주시면 감사하겠습니다.  
+LinM은 Linux용 텍스트 UI 파일 관리자입니다.  
+MS-DOS 시절 유명했던 Mdir의 리눅스 클론으로, Mdir의 단축키와 화면 구성을 최대한 유사하게 만들어 친숙하게 사용할 수 있습니다.
 
-* 인스톨
+파일 복사/이동/삭제, 디렉토리 트리 탐색, 파일 검색, 서브쉘 실행을 비롯해 FTP/SFTP, tar/zip/alz 아카이브 보기, RPM/DEB 패키지 탐색 등 다양한 기능을 제공합니다.
 
-   필요한 라이브러리 
-   
-    * ncurses 라이브러리가 필요합니다. (권장 5.3 버전이상)
-	  (http://www.gnu.org/software/ncurses/ncurses.html)	
-	  
-    * openssl 라이브러리가 필요합니다. (권장 0.9.6 이상)
-      (http://www.openssl.org)
-     
-	* samba client 라이브러리가 필요합니다. 
-	  (http://www.samba.org)	 
+- 오리지널 프로젝트: https://github.com/la9527/linm
+- 버그 리포트 및 문의: la9527@daum.net
 
-   # ./configure 
-   # make
-   # make install
+---
 
-    기본으로 깔리는 곳은 /usr/local로 깔립니다.
-    실행화일은 /usr/local/bin 깔리게 됩니다.
-    다른 곳에 인스톨하시려면
+## 사전 준비 (의존성 설치)
 
-    # ./configure --prefix=PATH
+### Debian / Ubuntu
 
-    기본 설정파일은 /etc/mls 에 깔립니다.
-    그리고 linm 종료시 해당 디렉토리로 이동하시려면, 
-    인스톨 후 다시 로그인을 하셔야 정상적으로 실행이 됩니다.	
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git gettext \
+    libncursesw5-dev libssl-dev libssh2-1-dev \
+    libsource-highlight-dev
+```
 
-    # ./configure --help 하시면 관련 컴파일 옵션이 나옵니다.
-    	 
-    관련 컴파일 옵션
-      
-      --enable-tarname=FILE      : tar 명 바꿈. (디폴트는 tar, gtar 두가지 중 자동으로 설정됩니다.)
-      --enable-cfgpath=DIR       : LinM 설정 파일 위치를 설정합니다. (디폴트 : /etc/linm)
-      --enable-kolocalefile=DIR  : 한글 로케일 파일 위치설정 (디폴트 : /usr/share/locale/ko/LC_MESSAGES)
-      --disable-pthread          : pthread 라이브러리 사용하지 않는다.     
-      --enable-debug             : 디버그 모드로 사용                  
-      --enable-allstatic         : static으로 컴파일. 관련 라이브러리가 없어도 실행가능하게 컴파일 
-      --disable-iconv            : iconv 라이브러리를 이용하지 않게 컴파일. 
-                                   static으로 컴파일해서 쓸때 사용.
-      --with-ncurses-prefix      : ncurses 설정
-      --disable-sftp             : sftp 사용하지 않음. openssl 을 이용하지 않음.
-      --disable-samba            : Samba 를 사용하지 않음. libsmbclient 을 이용하지 않음.
-      --with-openssl=DIR         : openssl 설정 (설정하지 않으면 자동으로 설정됩니다.)
-      --with-libz=DIR            : libz 설정 (설정하지 않으면 자동으로 설정됩니다.)
- 
-* 기본 사항
+### Arch Linux
 
-   1. 현재 프로그램 코딩은 ko_KR.UTF-8 로 되어 있습니다. 
-      따라서 기존의 euc-kr의 인코딩을 사용하시는 분은 utf-8로 
-      편집기 인코딩 설정을 바꿔서 사용하시기 바랍니다.
+```bash
+sudo pacman -S --needed base-devel cmake git gettext \
+    ncurses openssl libssh2 source-highlight
+```
 
-   2. 파일 구성
- 	 - 프로그램 인스톨시 자동으로 /etc/linm 밑에 설정화일을 복사 합니다.
- 	   (User계정일 경우에는 $HOME/.linm 밑에 설정파일들이 복사 됩니다.)
-   	  
-      1) default.cfg, colorset.cfg, keyset.cfg : LinM 설정파일들
-      2) linm.sh, linm_aliase.sh : LinM 종료시 최종 종료된 디렉토리로 이동하기 위한 쉘프로그램
-      3) linm_euckr.mo, linm_utf8.mo : 영문번역내용을 담은 파일
-      
-   3. 단축키
+### Fedora / RHEL / CentOS
 
-	Mls)
-		/       : 쉘
-		ESC     : Command 화면을 보여줌
-	
-		|       : 홈 디렉토리 이동
-		\       : 루트 디렉토리 이동
-		BS      : 부모 디렉토리 이동
-		
-		Alt+Q   : 이전 디렉토리로
-		Alt+W   : 앞 디렉토리로
-		Alt+C   : 파일 복사 (mcd 이용)
-		Alt+D   : 파일 삭제
-		Alt+K   : 디렉토리 만듦
-		Alt+R   : 이름바꾸기
-		Alt+V   : 파일보기
-		Alt+S   : 소트 변경
-		Alt+Z   : 숨긴 화일 보기
-		Alt+O   : 소유자 보기
+```bash
+# Fedora
+sudo dnf install -y gcc-c++ cmake git make gettext \
+    ncurses-devel openssl-devel libssh2-devel source-highlight-devel
 
-		Alt+L   : 박스를 +,-,| 형태 보여줌
-		Alt+H   : 파일모드바꿈(Chmod)
-		Alt+X,
-		Ctrl+Q  : Mls 종료
-		Alt+S   : 파일소트바꿈.
-	
-		Ctrl+A  : 전체선택
-		Ctrl+U  : 반전
-		SPACE   : 선택
-	
-		Alt+E   : 압축메뉴
-		Ctrl+L  : 영문모드 <-> 한글모드
-		Ctrl+W  : 다중뷰
-		Tab     : 다중뷰일 경우 다음화면
-		Ctrl+E  : 다중뷰일 경우 다음화면
-		Ctrl+N  : 새로운 문서
-	
-		Ctrl+C  : 클립 복사 
-		Ctrl+V  : 클립 붙여넣기
-		Ctrl+X  : 클립 잘라내기 (압축파일에서는 불가)
-	
-		F1      : 도움말
-		F2      : 이름수정
-		F3      : 보기
-		F4      : 에디터
-		F5      : 새로고침
-		F6      : 이동
-		F7      : 디렉토리 생성
-		F8      : 삭제
-		F9      : 압축메뉴
-		F10     : MCD
-		F11     : Quick Change Directory
-		F12     : 메뉴
-		
-		Ctrl+P	: sftp, ftp, samba 접속 설정 화면
-		Ctrl+R  : sftp, ftp, samba 빠른 접속
-		Alt+R   : sftp, ftp, samba 접속 종료
-		
-		Ctrl+G  : 마운트된 목록 보여줌.
-		Ctrl+O	: 콘솔모드 (MC 와 비슷한 서브쉘)
-		          콘솔모드에서 Ctrl+O를 누르면 LinM으로 되돌아감.
-		         
-		Ctrl+F  : 파일 찾기
-		Alt+I   : 파일 비교 
-		
-		Ctrl+B  : 설정 변경
-	
-	MCD)
-		F1      : 도움말
-		F2      : 이름수정
-		F3      : 전체 디렉토리 검색
-		F4      : 깊이를 3으로 검색
-		F5      : 새로고침
-		F6      : 이동
-		F7      : 디렉토리 생성
-		F8      : 디렉토리 삭제
-		F9      : 디렉토리 사이즈
-		F10     : 마운트된 목록 보여줌
-		F12     : 메뉴
-		
-		Alt+X, Ctrl+Q
-		        : MCD 종료
-		
-		Ctrl+R  : sftp, ftp, samba 접속
-		Alt+R   : sftp, ftp, samba 접속 종료		
+# CentOS/RHEL (EPEL 저장소 활성화 필요)
+sudo yum install -y gcc-c++ cmake3 git make gettext \
+    ncurses-devel openssl-devel libssh2-devel source-highlight-devel
+```
 
-		Ctrl+C  : 클립 복사 
-		Ctrl+V  : 클립 붙여넣기
-		Ctrl+X  : 클립 잘라내기 (압축파일에서는 불가)
-		
-		Ctrl+W  : 다중뷰
-		Tab     : 다중뷰일 경우 다음화면
-		Ctrl+E  : 다중뷰일 경우 다음화면
+---
 
-	Mls Editor)
-		F2      : 선택 모드
-		F3      : 다음 찾기
-		F5      : 찾기 
-		F5      : 새로고침
-		F6      : 라인 번호 보기
-		F8      : Vim 으로 보기
-		F12     : 메뉴
-				
-		Ctrl+N  : 새로운 문서
-		Ctrl+S  : 문서 저장
-		Ctrl+C  : 복사
-		Ctrl+X  : 자르기
-		Ctrl+V  : 붙여넣기
-		Ctrl+Z  : 실행취소
-		Ctrl+G  : 라인이동
-		Ctrl+F  : 찾기
-		Ctrl+R  : 바꾸기
-		
-		Alt+F   : 처음으로
-		Alt+E   : 마지막으로
-		Alt+X,
-		Ctrl+Q  : 에디터 종료
-		
-		Ctrl+W  : 다중뷰
-		F9      : 다중뷰일 경우 다음화면
-		Ctrl+E  : 다중뷰일 경우 다음화면
-		
-		Shift+방향키 : Gnome 콘솔에서만 사용가능(선택기능)
-		               기타 터미널은 F2 를 이용하여 선택
+## 빌드 및 설치
 
-  4. 압축 파일 지원 : tar, tar.gz, gz, bz2, tar.bz2, rpm, zip, deb, alz
+### 사용자 홈 경로 설치 (sudo 불필요, 권장)
 
-* 테스트 OS
+```bash
+git clone https://github.com/la9527/linm.git
+cd linm
 
-   - Redhat 9, Fedora 1~7
-   - Haansoft Linux 2006
-   - Ubuntu 7.10
-   - Gentoo 2007.01
+mkdir -p build && cd build
 
-* 알려진 문제점
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local ..
+make
+make install
+```
 
-   - 기본적으로 linm_aliase.sh (LinM 종료시 최종 종료된 디렉토리로 이동하기 위한 쉘프로그램)
-     는 기본적으로 /etc/profile.d 에 들어갑니다.
-     이것이 실행되지 않을 시 밑의 alias 내용을 홈디렉토리의 .bash_profile 에 추가하거나,
-     각자 초기 profile 에 넣어 주면 실행이 됩니다. (보통 데비안 리눅스)
+설치 후 `$HOME/.local/bin`이 `PATH`에 포함되어 있어야 합니다.
 
-            alias linm='. linm.sh'
-            
-   - 특정 서버 sftp 접속시 이유없이 패스워드가 틀렸다고 나오는 버그(찾는중)
+```bash
+# ~/.bashrc 또는 ~/.bash_profile에 추가
+export PATH="$HOME/.local/bin:$PATH"
+```
 
-* 홈페이지 (Wiki)
- 
-   http://wiki.kldp.org/wiki.php/Mls
-   
-* 프로젝트 홈페이지
+### 시스템 전역 설치
 
-   http://kldp.net/projects/mls/
-  
-* 개발자
+```bash
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make
+sudo make install
+```
 
-   라병영 la9527@daum.net        Project Manager
-   이승중 leesjung@nownuri.net      Developer
-   배상경 baesg@cntek.co.kr         Developer
-   서영섭 Youngseop, Seo            Developer
-   임채훈 fehead@gmail.net          Tester
-   최은서 eunseo.choi@gmail.com     Translator
-   김기태 bluetux@gmail.com         Designer
-   강우성 kayws426@gmail.com		   Developer
+---
 
-----------------------------------------------------------------------------------
+## linm.sh 경로 보정
 
-* LinM 0.8.1 에서 바뀐점.
-    추가
-    - 파일 바로찾기 기능 강화 (비슷한 파일 바로 찾기 기능 추가)
-    - 분할 화면이 아닌 한 윈도우에서 다음화면 이동하게 설정 추가
-    - 투명 콘솔 화면 설정 추가(기본 투명콘솔 단 검은색만)
-    
-    버그수정
-    - 한쪽창은 편집화면 한쪽창은 파일창일때 쉘모드시 커서 위치 버그 수정.
-	- linm.sh, linm.csh 버그 수정
-	- Ctrl+O SubShell path 버그 수정	
-	- 압축시 취소(Ctrl+C) 되게 수정
+현재 디렉토리를 유지하며 종료하려면 `linm` 바이너리 대신 `linm.sh` 스크립트를 통해 실행해야 합니다.
 
-* LinM 0.8 에서 바뀐점.
-	추가
-	* 환경 설정 화면 추가
-	* libssh2-0.18 업데이트
-	* 에디터에서 바꾸기(Replace) 기능 추가
-	* rar 압축풀기, iso 파일 보기 지원
-	
-	버그 수정
-	* 메뉴의 설정파일 수정 후 화면 오류 수정
-	* 마운트된 디렉토리 /dev 로 시작되는 내용만 보여주게 수정
-	* Editor 시 Right, Left 버튼을 계속 누르면 계속 밑으로 위로 가게 수정
-	* Ctrl+R 지원하지 않는 프로토콜 버그 수정
-	* 확장자별 실행연결에서 처음 실행파일이 없을 경우 설정한 다음실행파일로 수정
-	* 설정파일 확장자 리스트 추가
+```bash
+nano $HOME/.local/bin/linm.sh
+```
 
-* LinM 0.7.12 에서 바뀐점.
+실행 라인을 실제 바이너리 경로로 변경합니다:
 
-	추가
-	- Samba 접속 지원. (smb:// 로 접근 가능)
+```bash
+/home/<사용자명>/.local/bin/linm $@
+```
 
-	버그 수정
-	- 파일 복사시 ProgressBar 오류 수정.
-	- ko_KR.EUC-KR 로케일 인식 오류 수정.
-	- 리모트 파일 복사시 가끔 OverWrite 메시지 나오는 오류 수정.
-	- FreeBSD, GCC 2.9x 컴파일 오류 수정.
+---
 
-* LinM 0.7.11 에서 바뀐점.
-	
-	추가 
-	- 파일 검색 추가
-	- 파일 비교 추가(diff)
-	- 파일소유자 변경 추가
-	- LinM 설치시 실행 Icon 추가
-	- jar 보기 및 압축 풀기 지원
-	- alt+enter 시 프로그램 선택을 늘림 (default.cfg 수정)
-	- 엔터시 확장자 실행을 선택하는 옵션 추가.(default.cfg 의 Enter_RunSelect)
-	- 터미널 Title에 현재 디렉토리 위치 추가
+## Bash alias 등록
 
-	버그 수정	
-	- remove 시 커서  위치 버그 수정.
-	- 파일 복사시 같은 파일인 경우 rename 저장시 저장 되지 않는 오류 수정.
-	- 죽은 링크파일인 경우 보이지 않고, 디렉토리 삭제시 삭제 되지 않는 버그 수정.
-	- 파일 복사시 ProgressBar 에서 가끔 죽는 버그 수정.
-	- gz, bz2 파일 보기 버그 수정.
+```bash
+# ~/.bash_aliases 에 추가
+alias linm='. $HOME/.local/bin/linm.sh'
+```
 
-* LinM 0.7.10 에서 바뀐점.
-	
-	추가	
-	- MC 와 비슷한 ConsoleMode (Ctrl+O) 기능을 추가. 	
-	
-	버그 수정
-	- Mac PCC 의 컴파일 관련 버그 수정.
-	- 화면 힌트 내용 보완.
-	- 파일 복사시 같은 파일이 있을때 Rename 시 제대로 되지 않는 오류 수정.
-	- 현재 시스템 locale 이 ko_KR.utf8.eucKR 인 경우 영문으로 나오는 오류 수정.
-	- sftp 복사 관련 오류 수정.
-	- 입력창에서 커서위치 오류 수정. Rename 시 입력창에서 ESC 누를시 창닫게 수정.
-	- gettext 관련 프로그램 개선
-	- 입력 커서 포지션 버그 수정.
+점(`.`)과 공백이 반드시 있어야 현재 셸 세션에 디렉토리 변경이 반영됩니다.
 
-* LinM 0.7.9 에서 바뀐점.
+```bash
+source ~/.bash_aliases
+```
 
-	추가
+---
 
-	- 상대편 디렉토리와 같게 추가. (Ctrl+S)
-	- 화면 분할시 파일 복사(Atl+C) 및 이동시(Alt+M) 반대쪽 화면 디렉토리에 파일 복사 및 이동
-	- libssh2 0.14로 버전업.
+## 설정 파일
 
-	버그 수정
+설정 파일은 `$HOME/.config/linm/` 에 저장됩니다.
 
-	- 화면 오른쪽 한칸 잘림 문제 해결.
-	- 링크 디렉토리 지울시 실제 안의 파일까지 삭제되는 문제 수정.
-	- 링크 복사 및 삭제 관련 버그 수정.
-	- KDE Konsole 에서 SCIM 을 이용한 한글 입력 버그 수정.
-	- 처음 실행시 cfg 파일 바뀌는 메시지 계속 나오는 버그 수정.	
-	- 한컴 리눅스 안녕 리눅스 컴파일 버그 수정.
-	- sftp, ftp 접속후 Timeout 시 죽는 버그 수정.
-	- sftp 복사시 복사 시간이 느린 점 수정.
-	- make -j2 옵션 버그 수정.	
+| 파일 | 설명 |
+|------|------|
+| `default.cfg` | 일반 설정 (소트, 마우스, 투명도 등) |
+| `keyset.cfg` | 단축키 바인딩 |
+| `colorset.cfg` | 색상 설정 |
+| `syntexset.cfg` | 문법 강조 설정 |
 
-* LinM 0.7.8 버전에서 추가된 점.
+버전이 올라가면 실행 시 자동으로 새 키를 병합하고 프로그램을 재시작합니다.  
+기존 설정은 유지되며 `back/` 폴더에 백업됩니다.
 
-	추가 된점.
+---
 
-	- 접속 관리자 메뉴 추가.
-	- ssh 키 파일로 접근 가능하게 추가. 
-	  (인증키에 패스워드 넣는 것은 추후지원)
-	- 터미널 제목을 LinM 으로 바꿈.
+## 주요 단축키
 
-	버그 수정
-	  
-	- 환경설정 파일 수정시 특정 OS에서 죽는 버그 수정.
-	- 내부에디터에서 Select All 하고 지울시 가끔 죽는 버그 수정.
-	- QCD에서 한 항목을 delete시 화면 반영이 않된 문제 수정.
-	- TabSize 관련에러 문제점 수정.
-	- 파티션간 파일 이동시 에러 수정.
-	- 2GB 이상 파일 볼수 없는 문제 수정.
-	- AlwaysClearRefresh 환경변수 추가.
+### 패널 (파일 관리)
 
-* LinM 0.7.7 버전에서 추가된 점.
-	추가 된 점
-	
-	- sftp, ftp 복사시 한글일 경우 EUC-KR, UTF8 복사를 물어보게 수정.
-	- configure 시 설정파일, 한글 로케일 관련 인스톨 위치를 입력하게 추가 
-	  ( --enable-cfgpath, --enable-kolocalefile 옵션 설정추가)
-	- sftp, ftp에서 파일 편집하여 파일 저장시 파일이 자동으로 sftp, ftp로 저장되게 수정.
-	- OS 타입이 linux-gnu 이외에는 iconv, intl 라이브러리를 확인하고 링크해주게 변경. 
-	  (freebsd, cygwin 등을 위한 수정)
-	- F5 새로고침을 화면을 지우고 다시그리는 것으로 바꿈.
-	- Cygwin 컴파일 완료.
-	
-	버그 수정
-	
-	- 압축 파일 읽을때 파일을 읽을 수 없는 경우 에러메시지 처리 해주게 수정.
-	- sftp rename 버그 수정.
-	- 한글 Msg 오타 수정.
-	- gcc 2.95 compile error bugfix.
-	- 파일 복사 관련 2.3G 이상의 파일 복사 하게 수정.
-	- 파일 복사시 취소 버튼 버그 수정. (Progress 관련 버그수정)
-	- tar.gz 복사시 시간이 많이 걸리던 문제 수정.
-	- tmp 디렉토리를 ~/.linm/linmtmp_dir 로 바꾸고 tmp에 파일 지워짖 않은 버그 수정.
-	- cygwin 의 키코드 다른 문제 수정.
-	- default.cfg 파일 설정관련 버그 수정.
+| 키 | 기능 |
+|----|------|
+| `F1` | 도움말 |
+| `F2` | 이름 바꾸기 |
+| `F3` | 파일 보기 |
+| `F4` | 에디터 |
+| `F5` | 새로고침 |
+| `F7` | 디렉토리 생성 |
+| `F8` / `Alt+D` | 삭제 |
+| `F10` | MCD (디렉토리 트리) |
+| `F11` | QCD (빠른 디렉토리 이동) |
+| `F12` | 메뉴 |
+| `Alt+S` | 정렬 방식 선택 팝업 (None/Name/Ext/Size/Time/Color) |
+| `Alt+F` | 파일명 필터 (실시간, 디렉토리 제외, 이동 시 유지) |
+| `Alt+C` | 복사 |
+| `Alt+M` | 이동 |
+| `Alt+Z` | 숨김 파일 보기 토글 |
+| `Alt+X` / `Ctrl+Q` / `Ctrl+D` | 종료 |
+| `Ctrl+A` | 전체 선택 |
+| `Ctrl+U` | 선택 반전 |
+| `Space` | 파일 선택 |
+| `Ctrl+W` | 패널 분할/합치기 |
+| `Tab` / `Ctrl+E` | 다음 패널로 |
+| `Ctrl+O` | 서브쉘 (Ctrl+O로 복귀) |
+| `Ctrl+B` | 설정 변경 |
+| `Ctrl+F` | 파일 찾기 |
+| `BS` | 상위 디렉토리 |
+| `\` | 루트 디렉토리 |
+| `~` | 홈 디렉토리 |
+| `Alt+Q` / `Alt+W` | 이전/앞 디렉토리 |
+| `Ctrl+R` | FTP/SFTP 빠른 접속 |
+| `Alt+R` | FTP/SFTP 접속 종료 |
 
-* LinM 0.7.6 버전에서 추가된 점.
-	추가.
-	- zip 파일 view시 utf8, euckr 인식하게 수정. (일부 zip 파일은 한글이 깨진채로 들어가 있음)
-	- sftp, ftp 파일 복사시 local복사시에만 한글파일 euckr, utf8 변경 저장하게 수정.(추후 버전 remote도 지원.)
-	- MCD dir list 저장(file, sftp, ftp 따로 저장).
-	- 클립보드 내용보기 추가.	
-	- 한글 locale (linm_euckr.po, linm_utf8.po) 추가.
-	- Chmod 추가 및 checkbox 추가.
-	- Execute 추가(Alt+Enter)
-	- QCD 추가 (F11)
-	- Back, Forward 추가
-	- Extract 추가 (Alt+E)
-	- New File, TouchFile 추가.	
-	- Sehll History 추가 지원.
-	- Help, About 추가.
-	- Editor 에서 마우스 On,Off 추가.
-	- TextBox dialog 추가.
-	
-	버그수정.
-	- 선택박스에서 버튼 4개 이하 인 것은 가로로 나오게 수정.
-	- Path 버그 수정.
-	- ftp 에서 상위 디렉토리로 이동시 .. 으로 이동하는 버그 수정.
-	- tar.gz 빠져나올때 사용한 tar.gz 으로 이동하게 버그 수정.
-	- shell 실행시 에러내용 표시 않되는 것 수정.
-	- 컴파일관련 버그 수정.
-	- 메뉴선택에서 Config 파일 수정변경시 바뀌지 않는 버그 수정.
-	- Editor에서 패널 하나일 경우 전체 화면으로 나오게 수정.
-	- 에디터 전체 화면일 경우 마우스 끄게 수정.
-	- 선택모드일경우 커서 끔. 기타 커서 관련 버그 수정.
-	- 다이얼로그에서 마우스 클릭시 인식 버그 수정.
-	- Mcd Rscan시 자신 디렉토리로 이동되게 수정
-	- 일부 키제대로 되지 않는 문제 수정 (panel에서 home 디렉토리 이동 등)
-	- 압축시 Ctrl+C 인식되게 수정.
-	- MCD Rename 버그 수정.
-	- Mcd Remove 후 커서 / 이동 버그 수정.
-	- Editor 종료후 사용한 파일로 이동하게 버그 수정.
+### MCD (디렉토리 트리)
 
-* LinM 0.7.5b 베타 버전에 추가 된점
-	- sftp 지원, sftp 접속 파일 보기, sftp 접속 tar.gz 파일 보기, sftp <-> sftp 접속 지원
-	- Mcd Copy & Paste (Ctrl+C, Ctrl+V) Panel <-> Mcd 지원
-	- linm, mcd 에서 마운트 목록 보여주고 이동 (local 작업시)
-	- 키코드 제대로 되게  (F1~F10, 방향키 pageup, pagedown 등) 수정.	
-	- gcc 2.9 compile error 수정		
-	- Editor 시 filepath표시 없음 수정
-	- Editor 추가
-	- Editor 화면 버그 수정
-	- Editor 쪽 에서 vim editor로 편집 메뉴 추가	
-	- Alt+C, Alt+M 복사, 이동 추가
-	- selectbox title 내용 없는 버그 수정
-	- 메뉴 단축키 버그 수정	
-	
-	* 추가해야 할점. (추후 지원)
-		- MCD 내용 저장 		
-		- Help
-		- QCD
-		- Make TarGZ, BZ, Extract
-		- sftp, ftp 쪽에서 파일 복사할때 utf8 <-> euckr 상관없이 한글깨짐없이 복사 가능하게 변경.
-		- 한글화
+| 키 | 기능 |
+|----|------|
+| `F3` | 전체 디렉토리 검색 |
+| `F4` | 깊이 3으로 검색 |
+| `F5` | 새로고침 |
+| `F8` | 디렉토리 삭제 |
+| `F9` | 디렉토리 사이즈 |
 
-* LinM 0.7a 알파 버전 추가 된점 (2005-10-23)
-    - 기존 Mls 에서 LinM으로 실행파일과 패키지이름이 변경되었습니다.
-    - 프로그램 전체에 대한 마우스 인식 강화 (다이얼로그, Mcd, 메뉴 등)
-    - 화면 깜빡꺼림 제거. 화면 스크롤이 예전보다 빨라짐.
-    - ftp 지원, ftp 접속 파일 보기, ftp 접속 tar.gz 파일 보기, ftp <-> ftp 접속 지원
-    - mcd 화면이 전체 화면에서 패널에서도 지원하게 지원.
-    - Mcd, Panel 링크 지원.
-    - 기존의 Editor, QCD 등이 빠져있습니다. 다음 베타버전에는 들어갈 예정입니다.
+---
 
-* 0.6.7 버전에서 달라진 점
-  추 가
-	- Touchfile, 선택된 파일 리스트 저장 메뉴넣음.
-	- Alt+Enter 시 Parameter, Parameter(root) 넣음.
-	- Makefile.am 에 $(DESTDIR)을 넣음.
-	- Clip_Copy, Clip_Cut 일시 C, U 를 각각 화면에 보여줌.
-	- Mcd 에서 Search시 Tab 지원.
-	- 영문 메뉴얼 넣음.
-	- gcc 2.9x 버전 에러 수정	
-	
-  수 정
-	- Makefile.am Uninstall 시 mlseditor.key 파일 빠져있는 것을 수정.
-	- 현재 디렉토리가 없을때 종료할 경우 오류 수정	
-	- InputBox 가로크기 좀 크게 변경
-	- Mcd 디렉토리 정보보기 Ctrl+C 제대로 되지 않는 문제 수정.
-	- --with-ncurses-prefix configure 옵션 수정
-	- --enable-static 옵션 버그 수정
-	- Unalz 0.51 버전에서 날짜부분 수정
-	- 홈디렉토리에 있는 config 파일 버전이 다를시 파일을 
-	  /etc/mls에서 복사하는지 물어보게 수정.
-	- 에디터에서 DOS 모드로 종료하면 계속 DOS 모드로 읽어 들이는 문제 수정.
-	- Ctrl+Q(종료), Delete(삭제), Insert(복사) 의 단축키를 추가하였습니다.
+## 마우스 제어
 
-* 0.6.5 버전 달라진 점
-  추가 사항
-    - unalz 추가 - unalz 0.5 이상 버전에서 지원 (http://www.kipple.pe.kr/win/unalz/)
-	- MCD 에서 F9 를 디렉토리 정보 보기(파일 개수 및 사이즈)로 변경 기존 (F9 -> F4)
-	- Mls 파일 정보보기 (F9)넣음. 기존 압축 해제는 Ctrl+E로 변경. 	
-	- DOS 모드 읽기, 쓰기 넣음, 엔터시 들여쓰기 위치 켜기 끄기 넣음. 
-	- 에디터 들여쓰기, 들여쓰기 지움 넣음.
-	
-  수 정
-	- MCD 밑의 Function 메뉴를 한글이 나오게 수정
-	- 화면 버그 수정 및 선택 상태에서 붙여넣기 오류 수정
-	- tar.gz 에러시 이상하게 나오는 버그 수정 (화면 버그수정)
-	- mcd right 버튼시 그위치에 디렉토리가 없으면 밑으로 내려가게 수정.
-	- 쉘에서 cd 일때 탭버튼 누를 경우는 디렉토리만 검색되게 수정	
-	- 에디터에서 붙여넣기 시 라인 10 위치에 고정되는 것을 수정.
-	- Undo시 위치가 이상하게 되는 것을 수정.
-	- bug [300938] 삭제된 디렉토리에서 시작되었을 오류가 발생되는 문제 수정.
-	- FreeBSD, NetBSD 빌드 에러 수정 
+마우스 입력을 비활성화하려면 다음 중 하나를 사용합니다:
 
-* 0.6 버전에서 달라진 점
-  추 가	
-	- mls 전체 한글 입력 버그 수정
-	- mls shell 을 login@host:path$ 로 수정.
-	- 일부 콘솔의 Home, End, F1~F5 버튼 에러 수정
-	- chmod 추가 (alt+h)    
-	- 선택 실행을 추가 (alt+enter)
-	- 화면 밑에 hint 추가
-	- Mls에 Newfile, Root Run 추가    
-	- configure 에 --all-static 추가(리눅스 버전에 상관없이 컴파일 된 파일 사용가능하게)
-	- editor 추가. 
-		- 내부를 wchar_t로 변경 한글 처리 완성.
-		- select(F2), cut(ctrl+x), copy(ctrl+c), paste(ctrl+v), Undo(ctrl+z), Find(ctrl+f) 지원.
-		- Enter시 바로전 탭사이즈 위치로 이동, home 버튼 누를시 가장 앞의 문자 위치로 이동.
-		- utf-8, euc-kr 지원, save시 utf-8, euc-kr 변경 저장 가능
-    
-  수 정
-	- [ #300892 ] 접근권한 없는directory접근후에 tar 파일을 열때 에러 수정
-	- 설정 파일 버전 #!version 으로 내용 바꿈.
-	- 설정 파일에서 ExtEditor 내용이 있으면 에디터 설정된 내용으로 실행되게 변경
-	  없으면 내부 에디터 실행. (F3 : 내부, F4: 외부)
-	- Editor 에 처음으로, 마지막으로 넣음.
-	- User 계정에도 설치할수 있게 수정	
-	- rwSrwsrw- 이렇게 리눅스와 같은 파일 모드로 수정	
-	- shell의 프롬프트를 리눅스기본인 userid@hostname:path$ 로 바꿈.
-	- gz 파일 내용 보기 버그 수정	
+```bash
+# 커맨드라인 옵션
+linm --nomouse
+linm -M
 
-* 0.5 버전에서 달라진 점
-	- configure 에 --enable-debug, --enable-tarname, --disable-pthread 가 추가됨.
-	- Debian, RPM 패키지 파일 보기 및 파일 복사 가능
-	- Tar,rpm,deb 파일 내용중 Link File 버그 수정
-	- tar,zip,rpm,deb 파일 Clipboard 지원(copy & paste, remove(tar, zip만 가능)
-	- Console 화면을 움직일때 죽는 버그 최소화
-	- 압축 파일 안에서 엔터하면 바로 파일 보기(버그수정)
-	- Mls File Viewer 추가. Text 화일의 경우 Enter시 Mls Viewer로 보이게 함.
-	- 마우스 지원(아직 미흡함)
+# 환경변수
+LINM_NO_MOUSE=1 linm
 
-* 0.4.5 버전에서 달라진 점.  
+# default.cfg 설정
+Mouse = Off
+```
 
-	- FreeBSD 에서의 패치 추가
-	- 특정 디렉토리로 들어가면 프로그램이 죽는 현상 제거
-	- 다른 프로그램을 실행시키고 나서 잔상이 남는 현상 제거
-	- 파일 정렬에 문제가 있던 문제 제거
-	- 설정 파일 설치 스크립트 오작동 수정
-	- 펑션리스트, 메뉴리스트에 마우스 인식 작업
-	- 파일리스트에 마우스 대응은 추후에 할 예정임
-	- 설정상태 자동 저장 기능 추가
-	- 가로 상태바 고정 토글 기능 추가
-  
-* 0.4 버전에서 달라진 점.
+---
 
-	- 다국어 지원, 지금은 한국어만 있습니다
-	- 압축파일처리를 커맨드로 처리
-	- 압축파일 처리 부분등에서 쓰레드 지원
-	- 다중창 사용시 작업 디렉토리 바뀌지 않는 버그 수정
-	- 쉘커맨드에서 cd 지원
-  
-* 0.3 버전에서 달라진 점. 
-   
-	- 처음 초기화 실행에 Confiugre 파일을 읽어올 때 상황 보여줌.
-	- tar.gz, rpm, bz2, gz, zip 안에서 mcd 실행가능하게 함.
-	- zip 화일안에 있는 데이터를 실행가능하게 수정.
-	- rpm, tar.gz, bz2, gz, zip 화일을 바로 인스톨.(F9, alt+i)
-	- box를 (+,-,|)로 바꿔는 alt+l 추가 및 메뉴추가
-	- mls 실행 옵션을 추가. (--help, --noline, --mcd 등)
-	- mls, mcd 종료 팝업창을 mls.cfg 에서 조정하게 함.
-	- iconv 함수 추가로 euc-kr, utf-8 을 자동으로 감지.
-	- mcd 에서 디렉토리 체크 하여 체크 되지 않은 곳을 ? 표시
-	- zip 압축 풀리게 설정 따라서 안에 있는 파일을 소스를 볼수있음.
-	- 기타 자잘한 버그 수정.
+## 버전 이력
 
+| 버전 | 주요 변경 |
+|------|-----------|
+| 0.9.3 | Alt+F 파일 필터, Alt+S 정렬 팝업, 마우스 제어 옵션(--nomouse/-M/LINM_NO_MOUSE/Mouse=Off), 설정 자동 병합 및 재시작, Ctrl+D를 Quit 전용으로 변경 |
+| 0.9.2 | 설정 디렉토리 변경 (.linm → .config/linm), CMake 옵션 수정 |
+| 0.9.0 | automake → cmake 빌드 시스템 전환 |
+| 0.8.1 | Cygwin 화면 버그 수정, 쉘 모드 커서 버그 수정 |
+| 0.8.0 | LinM 설정 화면 추가 |
+
+---
+
+## 라이센스
+
+LinM은 GNU GPL v3 라이선스로 배포됩니다.  
+자세한 내용은 `LICENSE` 파일을 참고하세요.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It inherits the keyboard shortcuts and screen layout from Mdir for a familiar ex
 - Multi-panel view
 
 Original project: https://github.com/la9527/linm  
-Bug reports / contact: la9527@daum.net
+Bug reports / contact: zirize@gmail.com (fork) / la9527@daum.net (original)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,63 +2,386 @@
 
 ## Introduction
 
-  LinM is a visual file manager.
-  
-  It's a feature rich full-screen text mode application that allows you to copy, move and
-  delete files and whole directory trees, search for files and run commands in the sub-shell.
-   
-  LinM is best features are its ability to FTP, SFTP, view tar and zip, alz files, and to poke into RPMs for specific files, and DEB package.   
-  It's a clone of Mdir, the famous file manager from the MS-DOS age.
-  LinM inherits the keyboard shortcuts and the screen layout from Mdir to maximize user-friendliness.
-  
-  LinM project has not been managed for a long time.
-  We are inspired by a lot of encouragement. so it tries to restart the project. Thank you for encouragement.
-  
-  For bug reports, comments and questions, please email to la9527@daum.net
+LinM is a text-mode visual file manager for Linux — a clone of Mdir, the famous file manager from the MS-DOS era.
+It inherits the keyboard shortcuts and screen layout from Mdir for a familiar experience.
 
-## Installation Guide
+**Features:**
+- File copy, move, delete, and directory tree navigation
+- Built-in viewer and editor
+- FTP / SFTP support
+- Archive browsing: tar, zip, alz, RPM, DEB
+- Sub-shell (Ctrl+O)
+- Real-time file name filter (Alt+F)
+- Mouse support (optional)
+- Multi-panel view
 
-### System Requirements
-  
-   * ncurses (http://ftp.gnu.org/pub/gnu/ncurses/) (ver 5.3 or higher)
-     (http://www.gnu.org/software/ncurses/ncurses.html)	
+Original project: https://github.com/la9527/linm  
+Bug reports / contact: la9527@daum.net
 
-        > The way to find the 'ncurses' library is the first 'ncursesw', 
-        the second is 'ncurses', the third is 'curses'.         
+---
 
-   * cmake (3.x higher)
+## Requirements
 
-## Building LinM
+| Library | Min Version | Notes |
+|---------|-------------|-------|
+| ncursesw | 5.3+ | Wide-char ncurses required |
+| cmake | 3.x+ | Build system |
+| openssl | 0.9.6+ | SFTP support |
+| libssh2 | any | SFTP support |
+| source-highlight | any | Syntax highlighting (optional) |
 
-  * Supported Platforms
-      
-      - Linux
-      - Apple macOS
-      - FreeBSD
-      - OpenBSD
-      - Solaris
-      - AIX      
-      - Microsoft Windows
-      
-  * Build & Tested OS
-      
-      - Apple macOS Sierra 10.X
-      - Ubuntu Linux
+### Debian / Ubuntu
 
-  * Make
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git gettext \
+    libncursesw5-dev libssl-dev libssh2-1-dev \
+    libsource-highlight-dev
+```
 
-      - make -f Makefile.cvs
+### Arch Linux
 
-## License
+```bash
+sudo pacman -S --needed base-devel cmake git gettext \
+    ncurses openssl libssh2 source-highlight
+```
 
- LinM is distributed under the GNU Version 3.
- See ['LICENSE'] for the detail.
+### Fedora / RHEL / CentOS
+
+```bash
+# Fedora
+sudo dnf install -y gcc-c++ cmake git make gettext \
+    ncurses-devel openssl-devel libssh2-devel source-highlight-devel
+
+# CentOS/RHEL (enable EPEL first)
+sudo yum install -y gcc-c++ cmake3 git make gettext \
+    ncurses-devel openssl-devel libssh2-devel source-highlight-devel
+```
+
+---
+
+## Building & Installing
+
+### User-local install (recommended, no sudo)
+
+```bash
+git clone https://github.com/la9527/linm.git
+cd linm
+
+mkdir -p build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local ..
+make
+make install
+```
+
+Make sure `$HOME/.local/bin` is in your `PATH`:
+
+```bash
+# Add to ~/.bashrc or ~/.bash_profile
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### System-wide install
+
+```bash
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make
+sudo make install
+```
+
+### CMake options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `CMAKE_INSTALL_PREFIX` | `/usr/local` | Install prefix |
+| `LINM_CFGPATH` | `<prefix>/etc/linm` | System config file path |
+
+---
+
+## Post-install: linm.sh path fix
+
+To preserve the current directory on exit, run linm via the wrapper script (`linm.sh`) rather than the binary directly.
+
+Open `$HOME/.local/bin/linm.sh` and update the exec line to the actual binary path:
+
+```bash
+/home/<username>/.local/bin/linm $@
+```
+
+---
+
+## Bash alias
+
+```bash
+# Add to ~/.bash_aliases
+alias linm='. $HOME/.local/bin/linm.sh'
+```
+
+The leading `.` (source) is required so that the directory change is applied to the current shell session.
+
+```bash
+source ~/.bash_aliases
+```
+
+---
+
+## Configuration
+
+Config files are stored in `$HOME/.config/linm/`:
+
+| File | Purpose |
+|------|---------|
+| `default.cfg` | General settings (sort, mouse, transparency, …) |
+| `keyset.cfg` | Key bindings |
+| `colorset.cfg` | Color scheme |
+| `syntexset.cfg` | Syntax highlighting rules |
+
+When the version changes, LinM automatically merges new keys from the system defaults into your config, backs up the old files to `back/`, and restarts itself — your customizations are never overwritten.
+
+---
+
+## Key Bindings
+
+### Panel (file manager)
+
+| Key | Action |
+|-----|--------|
+| `F1` | Help |
+| `F2` | Rename |
+| `F3` | View file |
+| `F4` | Editor |
+| `F5` | Refresh |
+| `F7` | Make directory |
+| `F8` / `Alt+D` | Delete |
+| `F10` | MCD (directory tree) |
+| `F11` | QCD (quick change dir) |
+| `F12` | Menu |
+| `Alt+S` | Sort mode popup (None/Name/Ext/Size/Time/Color) |
+| `Alt+F` | File name filter (real-time, dirs excluded, persists across navigation) |
+| `Alt+C` | Copy |
+| `Alt+M` | Move |
+| `Alt+Z` | Toggle hidden files |
+| `Alt+X` / `Ctrl+Q` / `Ctrl+D` | Quit |
+| `Ctrl+A` | Select all |
+| `Ctrl+U` | Invert selection |
+| `Space` | Toggle select |
+| `Ctrl+W` | Split / unsplit panel |
+| `Tab` / `Ctrl+E` | Switch to next panel |
+| `Ctrl+O` | Sub-shell (Ctrl+O to return) |
+| `Ctrl+B` | Settings |
+| `Ctrl+F` | Find file |
+| `BS` | Parent directory |
+| `\` | Root directory |
+| `~` | Home directory |
+| `Alt+Q` / `Alt+W` | Back / Forward directory |
+| `Ctrl+R` | FTP/SFTP quick connect |
+| `Alt+R` | FTP/SFTP disconnect |
+
+### MCD (directory tree)
+
+| Key | Action |
+|-----|--------|
+| `F3` | Scan all directories |
+| `F4` | Scan depth 3 |
+| `F5` | Refresh |
+| `F8` | Remove directory |
+| `F9` | Directory size info |
+
+---
+
+## Mouse Control
+
+Mouse input can be disabled in several ways:
+
+```bash
+# Command-line option
+linm --nomouse
+linm -M
+
+# Environment variable
+LINM_NO_MOUSE=1 linm
+
+# In default.cfg
+Mouse = Off
+```
+
+---
 
 ## Changes
 
-v0.9.0 - 2017-08-24
+### v0.9.3
 
-    - build packaging is change from automake to cmake.
-    - fix compile warning.
-    - Fixed syntax highlighter in internal editor.
+- **Alt+F** real-time file name filter (directories always shown; filter persists on directory change; ESC or Alt+F again to clear)
+- **Alt+S** sort mode popup — choose None / Name / Ext / Size / Time / Color on the fly
+- **Mouse control**: `--nomouse` / `-M` CLI flag, `LINM_NO_MOUSE` env var, `Mouse = On/Off` in `default.cfg`
+- **Smart config merge**: on version upgrade, missing keys are merged from system defaults; existing settings preserved; old files backed up; process auto-restarts via `execvp` so all settings take effect immediately
+- **Ctrl+D** reassigned to Quit only (removed from Delete)
+- F1 help reorganized into logical groups
+
+### v0.9.2
+
+- Config directory changed from `.linm` to `.config/linm`
+- Fixed segfault when `LastPath` is invalid
+- Fixed repeated copy prompt on config version mismatch
+- CMake options `LINM_CFGPATH` / `LINM_BINPATH` fixed
+
+### v0.9.0
+
+- Build system migrated from automake to CMake
+
+---
+
+## Supported Platforms
+
+- Linux
+- Apple macOS
+- FreeBSD / OpenBSD
+- Solaris / AIX
+
+---
+
+## License
+
+LinM is distributed under the GNU General Public License v3.  
+See `LICENSE` for details.
+
+---
+
+## 한국어 설치 가이드 (Korean Installation Guide)
+
+LinM은 Linux용 텍스트 UI 파일 관리자(Mdir 클론)입니다.  
+이 섹션은 **한국어 사용자**를 위한 단계별 설치 안내입니다.
+
+### 1단계) 의존성 설치 (관리자 권한 필요)
+
+#### Debian / Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake git gettext \
+    libncursesw5-dev libssl-dev libssh2-1-dev \
+    libsource-highlight-dev
+```
+
+#### Arch Linux
+
+```bash
+sudo pacman -S --needed base-devel cmake git gettext \
+    ncurses openssl libssh2 source-highlight
+```
+
+#### Fedora
+
+```bash
+sudo dnf install -y gcc-c++ cmake git make gettext \
+    ncurses-devel openssl-devel libssh2-devel \
+    source-highlight-devel
+```
+
+#### CentOS / RHEL (EPEL 저장소 활성화 필요)
+
+```bash
+sudo yum install -y gcc-c++ cmake3 git make gettext \
+    ncurses-devel openssl-devel libssh2-devel \
+    source-highlight-devel
+```
+
+---
+
+### 2단계) 소스 클론 및 사용자 경로 설치
+
+`sudo` 없이 사용자 홈 경로(`$HOME/.local`)에 설치합니다. 시스템 전역 환경에 영향을 주지 않아 안전합니다.
+
+```bash
+git clone https://github.com/la9527/linm.git
+cd linm
+
+mkdir -p build
+cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local ..
+make
+make install
+```
+
+설치 후 `$HOME/.local/bin`이 `PATH`에 없다면 `~/.bashrc`에 추가합니다:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+source ~/.bashrc
+```
+
+---
+
+### 3단계) `linm.sh` 경로 보정
+
+종료 후 마지막 디렉토리를 유지하려면 바이너리(`linm`) 대신 래퍼 스크립트(`linm.sh`)로 실행해야 합니다.
+
+1. 스크립트 파일 열기:
+   ```bash
+   nano $HOME/.local/bin/linm.sh
+   ```
+
+2. 실행 라인을 확인합니다. 설치 직후 `@bindir@/linm $@` 또는 `OFF/linm $@` 형태로 되어 있을 수 있습니다. **실제 바이너리 경로**로 바꿉니다:
+   ```bash
+   /home/<사용자명>/.local/bin/linm $@
+   ```
+   예) 사용자명이 `zirize`인 경우:
+   ```bash
+   /home/zirize/.local/bin/linm $@
+   ```
+
+---
+
+### 4단계) Bash alias 등록
+
+`~/.bashrc`를 직접 수정하는 대신 `~/.bash_aliases`에 alias를 등록하는 방식을 권장합니다.
+
+1. 파일 열기 (없으면 자동 생성):
+   ```bash
+   nano ~/.bash_aliases
+   ```
+
+2. 다음 한 줄을 추가합니다:
+   ```bash
+   alias linm='. $HOME/.local/bin/linm.sh'
+   ```
+   > ⚠️ 앞의 점(`.`)과 공백이 반드시 있어야 합니다. 없으면 종료 후 디렉토리 이동이 현재 셸에 반영되지 않습니다.
+
+3. 적용:
+   ```bash
+   source ~/.bash_aliases
+   source ~/.bashrc
+   ```
+
+`~/.bash_aliases`가 자동으로 로드되지 않는다면 `~/.bashrc`에 다음이 있는지 확인하세요:
+
+```bash
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+```
+
+---
+
+### 5단계) 동작 확인
+
+```bash
+linm
+```
+
+실행 후 아무 디렉토리로 이동하고 종료했을 때, 터미널 현재 경로가 마지막 작업 위치로 바뀌면 정상 설치된 것입니다.
+
+---
+
+### 버전 업그레이드 시 참고
+
+새 버전을 빌드·설치한 후 처음 실행하면 설정 파일을 자동으로 업그레이드합니다:
+- 기존 설정을 `~/.config/linm/back/`에 백업
+- 새로운 설정 키만 병합 (기존 커스터마이징 유지)
+- 설정 반영을 위해 자동 재시작
+
+별도로 설정을 초기화할 필요가 없습니다.
 

--- a/configure.in
+++ b/configure.in
@@ -1,7 +1,7 @@
 AC_INIT(configure.in)
 
 AM_CONFIG_HEADER(config.h)
-AM_INIT_AUTOMAKE(linm, 0.9.3)
+AM_INIT_AUTOMAKE(linm, 0.9.4)
 
 dnl  **************************************************************
 AC_LANG_CPLUSPLUS

--- a/configure.in
+++ b/configure.in
@@ -1,7 +1,7 @@
 AC_INIT(configure.in)
 
 AM_CONFIG_HEADER(config.h)
-AM_INIT_AUTOMAKE(linm, 0.8.1)
+AM_INIT_AUTOMAKE(linm, 0.9.3)
 
 dnl  **************************************************************
 AC_LANG_CPLUSPLUS

--- a/configure.in
+++ b/configure.in
@@ -1,7 +1,7 @@
 AC_INIT(configure.in)
 
 AM_CONFIG_HEADER(config.h)
-AM_INIT_AUTOMAKE(linm, 0.9.4)
+AM_INIT_AUTOMAKE(linm, 0.9.5)
 
 dnl  **************************************************************
 AC_LANG_CPLUSPLUS

--- a/lib/configure.cpp
+++ b/lib/configure.cpp
@@ -67,6 +67,41 @@ namespace MLSUTIL {
         return true;
     }
 
+    void Configure::MergeFromFile(const string &sFilename) {
+        if (sFilename.empty()) return;
+
+        ifstream in(sFilename.c_str());
+        if (!in) return;
+
+        string line, var, val, section, name;
+
+        while (!getline(in, line).eof()) {
+            if (line.empty()) continue;
+            if (Tolower(line.substr(0, 10)) == "#!version ") continue;
+            if (line[0] == '#') continue;
+            if (line[0] == '[') {
+                section = getbetween(line, '[', ']');
+                continue;
+            }
+
+            string::size_type p = line.find('=');
+            if (p == string::npos) continue;
+
+            var = chop(line.substr(0, p));
+            val = chop(line.substr(p + 1));
+            if (var.empty() || var == "version") continue;
+
+            if (section != "")
+                name = Tolower(section) + "." + Tolower(var);
+            else
+                name = Tolower(var);
+
+            // Only insert if the key does not yet exist in this config
+            if (_EnvMap.find(name) == _EnvMap.end())
+                _EnvMap.insert(MapType::value_type(name, Entry(var, val, section, true)));
+        }
+    }
+
     bool Configure::Save(const string &sFilename) {// save the current file.
         string bakfile = _sFilename, srcfile;
 
@@ -95,6 +130,9 @@ namespace MLSUTIL {
 
         SaveParcing();
 
+        if (_sVersion.size() != 0)
+            out << "#!version " << _sVersion << endl;
+
         // Modified
         MapType::iterator i = _EnvMap.begin(), end = _EnvMap.end(), j;
         MapType mod_list, dup_list;
@@ -108,6 +146,8 @@ namespace MLSUTIL {
 
         if (in) {
             while (!getline(in, line).eof()) {
+                if (Tolower(line.substr(0, 10)) == "#!version ") continue;
+
                 if (line.empty() || line[0] == '#' || line[0] == '$') {
                     out << line << endl;
                     continue;

--- a/lib/configure.h
+++ b/lib/configure.h
@@ -62,7 +62,12 @@ namespace MLSUTIL {
 
         bool Save(const string &sFile = "");
 
+        // Merge keys from sFile that do not already exist in this config.
+        // Existing user settings are never overwritten.
+        void MergeFromFile(const string &sFile);
+
         const string &getVersion() const { return _sVersion; }
+        void setVersion(const string &sVersion) { _sVersion = sVersion; }
 
         void SetValue(const string &section,
                       const string &var,

--- a/lib/mlslocale.cpp
+++ b/lib/mlslocale.cpp
@@ -134,10 +134,11 @@ namespace MLSUTIL
 		if (strcmp (to_codeset, from_codeset) == 0)
 		{
 			char *p;
-			p = (char*)malloc (sizeof(char) * (strlen (str) + 1));
+			size_t slen = strlen(str) + 1;
+			p = (char*)malloc (sizeof(char) * slen);
 			if (!p)
 				return NULL;
-				strcpy (p, str);
+			memcpy (p, str, slen);
 			return p;
 		}
 	
@@ -147,9 +148,8 @@ namespace MLSUTIL
 			return NULL;
 	
 		p = (char*)malloc (sizeof(char) * (strlen (str) + 1));
-		strcpy (p, str);
-	
 		if (p == NULL) return NULL;
+		memcpy (p, str, strlen (str) + 1);
 	
 		len = strlen (p);
 		startp = p;

--- a/linm.spec
+++ b/linm.spec
@@ -4,7 +4,7 @@
 
 Summary: 		LinM visual shell
 Name: 			linm
-Version: 		0.9.3
+Version: 		0.9.4
 Release:		1
 Vendor: 		Shells
 #Copyright: 	GPL
@@ -12,7 +12,7 @@ License: 		GPL
 Group: 			System Environment
 Packager: 		Byoungyoung, La
 BuildRoot: 		%{_tmppath}/%{name}-%{version}-root
-Source: 		linm-0.9.3-1.tar.gz
+Source: 		linm-0.9.4-1.tar.gz
 URL:			http://mls.kldp.net
 BuildRequires:	ncurses-devel >= 5.2.0, openssl-devel >= 0.9.6, samba-common >= 3.0.0
 Requires: 		ncurses >= 5.2.0, openssl >= 0.9.6, samba-common >= 3.0.0
@@ -78,7 +78,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 * Sat Mar 14 2026 Byoungyoung La, <la9527@daum.net>
-- 0.9.3 version make
+- 0.9.4 version make
 - Add Alt+F real-time filename filter feature
 - Add --nomouse / LINM_NO_MOUSE option to disable mouse
 - Add Mouse = On/Off option in default.cfg

--- a/linm.spec
+++ b/linm.spec
@@ -4,7 +4,7 @@
 
 Summary: 		LinM visual shell
 Name: 			linm
-Version: 		0.8
+Version: 		0.9.3
 Release:		1
 Vendor: 		Shells
 #Copyright: 	GPL
@@ -12,7 +12,7 @@ License: 		GPL
 Group: 			System Environment
 Packager: 		Byoungyoung, La
 BuildRoot: 		%{_tmppath}/%{name}-%{version}-root
-Source: 		linm-0.8-1.tar.gz
+Source: 		linm-0.9.3-1.tar.gz
 URL:			http://mls.kldp.net
 BuildRequires:	ncurses-devel >= 5.2.0, openssl-devel >= 0.9.6, samba-common >= 3.0.0
 Requires: 		ncurses >= 5.2.0, openssl >= 0.9.6, samba-common >= 3.0.0
@@ -77,6 +77,16 @@ rm -rf $RPM_BUILD_ROOT
 %dir %{_datadir}/*
 
 %changelog
+* Sat Mar 14 2026 Byoungyoung La, <la9527@daum.net>
+- 0.9.3 version make
+- Add Alt+F real-time filename filter feature
+- Add --nomouse / LINM_NO_MOUSE option to disable mouse
+- Add Mouse = On/Off option in default.cfg
+- Improve Alt+S sort selection with popup menu
+- Reorganize F1 help with logical grouping and ordered display
+* Tue Mar 03 2026 Byoungyoung La, <la9527@daum.net>
+- 0.9.2 version make
+- Change default config directory to .config/linm
 * Sun Feb 10 2008 Byoungyoung La, <la9527@daum.net>
 - 0.8.1 version make
 * Mon Dec 31 2007 Byoungyoung La, <la9527@daum.net>

--- a/linm.spec
+++ b/linm.spec
@@ -4,7 +4,7 @@
 
 Summary: 		LinM visual shell
 Name: 			linm
-Version: 		0.9.4
+Version: 		0.9.5
 Release:		1
 Vendor: 		Shells
 #Copyright: 	GPL
@@ -12,7 +12,7 @@ License: 		GPL
 Group: 			System Environment
 Packager: 		Byoungyoung, La
 BuildRoot: 		%{_tmppath}/%{name}-%{version}-root
-Source: 		linm-0.9.4-1.tar.gz
+Source: 		linm-0.9.5-1.tar.gz
 URL:			http://mls.kldp.net
 BuildRequires:	ncurses-devel >= 5.2.0, openssl-devel >= 0.9.6, samba-common >= 3.0.0
 Requires: 		ncurses >= 5.2.0, openssl >= 0.9.6, samba-common >= 3.0.0
@@ -78,7 +78,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 * Sat Mar 14 2026 Byoungyoung La, <la9527@daum.net>
-- 0.9.4 version make
+- 0.9.5 version make
 - Add Alt+F real-time filename filter feature
 - Add --nomouse / LINM_NO_MOUSE option to disable mouse
 - Add Mouse = On/Off option in default.cfg

--- a/panel/common/keycfgload.cpp
+++ b/panel/common/keycfgload.cpp
@@ -116,7 +116,7 @@ bool	KeyCfgLoad::Parsing(const string& sSection, const string& sVar, const strin
 		tType.sValue = sVar;
 
 		// gettext style reading.
-		_mapKeyHelp[ &tType ] = getbetween(sVal, '\"', '\"');
+		_mapKeyHelp.push_back({ &tType, getbetween(sVal, '\"', '\"') });
 	}
 	return false;
 }
@@ -209,12 +209,11 @@ string	KeyCfgLoad::GetCommand( const KeyInfo& tKeyInfo, const ViewType eType )
 
 string	KeyCfgLoad::GetHelp(const TypeInfo& tType)
 {
-	map<TypeInfo*, string>::iterator i;
+	vector<pair<TypeInfo*, string>>::iterator i;
 	string 		sTmpCmd;
 
 	for (i = _mapKeyHelp.begin(); i != _mapKeyHelp.end(); ++i)
 	{
-		//LOG("GetCommand [%s] [%s] [%s] ", i->second.c_str(), i->first.c_str(), sKeyName.c_str());
 		if (tType == *(i->first))
 			return i->second;
 		if ( i->first->sValue == tType.sValue && i->first->eType == COMMON )
@@ -231,10 +230,9 @@ string	KeyCfgLoad::GetHelp_Key(const string& sKeyName, const ViewType eType)
 	TypeInfo	tTypeInfo(sCmd, eType);
 	string 		sTmpCmd;
 
-	map<TypeInfo*, string>::iterator i;
+	vector<pair<TypeInfo*, string>>::iterator i;
 	for (i = _mapKeyHelp.begin(); i != _mapKeyHelp.end(); ++i)
 	{
-		//LOG("GetCommand [%s] [%s] [%s] ", i->second.c_str(), i->first.c_str(), sKeyName.c_str());
 		if (tTypeInfo == *(i->first))
 			return i->second;
 		if ( i->first->sValue == sCmd && i->first->eType == COMMON )
@@ -249,42 +247,10 @@ string	KeyCfgLoad::GetHelp(const string& sCmd, const ViewType eType)
 	TypeInfo	tTypeInfo(sCmd, eType);
 	string 		sTmpCmd;
 
-	map<TypeInfo*, string>::iterator i;
+	vector<pair<TypeInfo*, string>>::iterator i;
 
-	/*
-	if ( sCmd.substr(0, 4) == "Cmd_" && e_nCurLang != US )
-	{
-		// convert to locale help message.
-		string sLang;	
-		if ( getenv("LANG") )
-			sLang = getenv("LANG");
-		
-		StringToken		tToken(sLang, " .");
-		tToken.Next();
-		sLang = tToken.Get();
-
-		tTypeInfo.sValue = sLang + sCmd.substr(3);
-
-		for (i = _mapKeyHelp.begin(); i != _mapKeyHelp.end(); ++i)
-		{
-			//LOG("GetCommand [%s] [%s] [%s] ", i->second.c_str(), i->first.c_str(), sKeyName.c_str());
-			if (tTypeInfo == *(i->first))
-				return ChgCurLocale(i->second);
-			
-			if ( i->first->sValue == tTypeInfo.sValue && i->first->eType == COMMON )
-			{
-				sTmpCmd = i->second;
-			}
-		}
-		
-		if (sTmpCmd.size() > 0 ) return ChgCurLocale(sTmpCmd);
-		tTypeInfo.sValue = sCmd;
-	}
-	*/
-	
 	for (i = _mapKeyHelp.begin(); i != _mapKeyHelp.end(); ++i)
 	{
-		//LOG("GetCommand [%s] [%s] [%s] ", i->second.c_str(), i->first.c_str(), sKeyName.c_str());
 		if (tTypeInfo == *(i->first))
 			return i->second;
 		if ( i->first->sValue == sCmd && i->first->eType == COMMON )
@@ -297,7 +263,7 @@ string	KeyCfgLoad::GetHelp(const string& sCmd, const ViewType eType)
 
 string	KeyCfgLoad::GetHelp(const KeyInfo& tKeyInfo, const ViewType eType)
 {
-	map<TypeInfo*, string>::iterator i;
+	vector<pair<TypeInfo*, string>>::iterator i;
 	string		sKeyName, sTmpHelp;
 	bool		bFind = false;
 
@@ -319,7 +285,6 @@ string	KeyCfgLoad::GetHelp(const KeyInfo& tKeyInfo, const ViewType eType)
 
 		for (i = _mapKeyHelp.begin(); i != _mapKeyHelp.end(); ++i)
 		{
-			//LOG("GetCommand [%s] [%s] [%s] ", i->second.c_str(), i->first.c_str(), sKeyName.c_str());
 			if ( i->second == sKeyName )
 			{
 				if (eType == i->first->eType)

--- a/panel/common/keycfgload.h
+++ b/panel/common/keycfgload.h
@@ -198,8 +198,8 @@ public:
 					const string& val);
 
 public:
-	// map< key command, help >
-	map<TypeInfo*, string>	_mapKeyHelp;
+	// vector< TypeInfo*, help text > — ordered by insertion (config file order)
+	vector<pair<TypeInfo*, string>>	_mapKeyHelp;
 
 protected:
 	// map< key command, key Name  >

--- a/panel/common/panel.cpp
+++ b/panel/common/panel.cpp
@@ -43,6 +43,10 @@ void	Panel::Init()
 	_uSelSize = 0;
 	_bSearch = false;
 
+	_bFilterMode = false;
+	_sFilterStr.clear();
+	_vFilterFiles.clear();
+
 	_tMemFile.Clear();	
 	_vDirFiles.clear();
 }
@@ -265,6 +269,10 @@ bool	Panel::Read(const string& sPathConst)
 		pReader->SetErrMsgShow(false); // 메시지 박스 보이지 않게.
 	}
 
+	// Save filter state across directory changes
+	bool bSaveFilterMode = _bFilterMode;
+	string sSaveFilterStr = _sFilterStr;
+
 	// . panel init
 	Init();
 
@@ -291,6 +299,13 @@ bool	Panel::Read(const string& sPathConst)
 	}
 
 	Sort();
+
+	// Restore filter state after directory load
+	if (bSaveFilterMode) {
+		_bFilterMode = true;
+		_sFilterStr = sSaveFilterStr;
+		ApplyFilter();
+	}
 
 	_pReader = pReader;
 
@@ -336,10 +351,11 @@ void	Panel::Key_Left()
 /// @brief	오른쪽 방향 키
 void	Panel::Key_Right()
 {
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
 	int nCur;
 	nCur = _uCur+_nRow;
-	if (nCur > (int)_vDirFiles.size()-1)
-		nCur = _vDirFiles.size()-1;
+	if (nCur > (int)vFiles.size()-1)
+		nCur = vFiles.size()-1;
 	SetCur(nCur);
 	_bChange = false;
 }
@@ -355,7 +371,8 @@ void	Panel::Key_Up()
 /// @brief	아래쪽 방향키
 void	Panel::Key_Down()
 {
-	if (_uCur < _vDirFiles.size()-1)
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+	if (_uCur < vFiles.size()-1)
 		SetCur(_uCur+1);
 	_bChange = false;
 }
@@ -373,10 +390,11 @@ void	Panel::Key_PageUp()
 /// @brief	page down key
 void	Panel::Key_PageDown()
 {
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
 	int nCur;
 	nCur = _uCur + (_nRow*_nCol);
-	if (nCur > (int)_vDirFiles.size()-1)
-		nCur=_vDirFiles.size()-1;
+	if (nCur > (int)vFiles.size()-1)
+		nCur=vFiles.size()-1;
 
 	SetCur(nCur);
 	_bChange = false;
@@ -392,38 +410,42 @@ void	Panel::Key_Home()
 /// @brief	Key End
 void	Panel::Key_End()
 {
-	SetCur(_vDirFiles.size()-1);	
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+	SetCur(vFiles.size()-1);	
 	_bChange = false;
 }
 
 void	Panel::SelectExecute()
 {
+	File* pCurFile = GetCurFile();
+	if (!pCurFile) return;
+
 	// 파일 실행
-	if (_pReader->isChkFile(*_vDirFiles[_uCur]) == false)
+	if (_pReader->isChkFile(*pCurFile) == false)
 	{
 		return;
 	}
 
 	vector<string> 	q;
 
-	string 	sFileName 	= MLSUTIL::addslash( _vDirFiles[_uCur]->sFullName );
-	string 	sPrgExeCmd	= g_tCfg.GetExtBind(_vDirFiles[_uCur]->Ext());
+	string 	sFileName 	= MLSUTIL::addslash( pCurFile->sFullName );
+	string 	sPrgExeCmd	= g_tCfg.GetExtBind(pCurFile->Ext());
 	string 	sCmd;
 
 	vector<string>		vCmd, vView;
 		
 	if (sPrgExeCmd.size() == 0) 
 	{
-		sPrgExeCmd = g_tCfg.GetNameBind(_vDirFiles[_uCur]->sName);
+		sPrgExeCmd = g_tCfg.GetNameBind(pCurFile->sName);
 	}
 
 	LOG("SelectExecute :: [%s]", sPrgExeCmd.c_str());
 
 	if (sPrgExeCmd.size() == 0)
 	{
-		if (_vDirFiles[_uCur]->isExecute())
+		if (pCurFile->isExecute())
 		{
-			sCmd = MLSUTIL::addslash( _vDirFiles[_uCur]->sFullName );
+			sCmd = MLSUTIL::addslash( pCurFile->sFullName );
 		}
 	}
 	else
@@ -529,9 +551,10 @@ void	Panel::SelectExecute()
 /// @brief	Key Enter
 void	Panel::Key_Enter()
 {
-	if ( _vDirFiles.size() <= _uCur ) return;
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+	if ( vFiles.size() <= _uCur ) return;
 
-	File*	pFile = _vDirFiles[_uCur];
+	File*	pFile = vFiles[_uCur];
 
 	if (pFile->bDir)
 	{
@@ -739,13 +762,15 @@ void Panel::Deselect(File &f)
 /// @brief	현재 파일 선택
 void Panel::ToggleSelect()
 {
-	if (_vDirFiles[_uCur]->bSelected)
+	File* pCurFile = GetCurFile();
+	if (!pCurFile) return;
+	if (pCurFile->bSelected)
 	{
-		Deselect(*_vDirFiles[_uCur]);
+		Deselect(*pCurFile);
 	}
 	else
 	{
-		Select(*_vDirFiles[_uCur]);
+		Select(*pCurFile);
 	}
 }
 
@@ -822,7 +847,79 @@ Panel::SearchProcess(KeyInfo&	tKeyInfo)
 	return false;
 }
 
-/// @brief	비슷한 이름을 가진 파일을 찾는다.
+void Panel::ApplyFilter()
+{
+	_vFilterFiles.clear();
+	if (_sFilterStr.empty())
+	{
+		_vFilterFiles = _vDirFiles;
+	}
+	else
+	{
+		string sLower = Tolower(_sFilterStr);
+		for (int i = 0; i < (int)_vDirFiles.size(); i++)
+		{
+			File* pFile = _vDirFiles[i];
+			if (pFile->bDir || Tolower(pFile->sName).find(sLower) != string::npos)
+				_vFilterFiles.push_back(pFile);
+		}
+	}
+
+	// Adjust cursor within filtered list
+	if (_uCur >= _vFilterFiles.size())
+		_uCur = _vFilterFiles.empty() ? 0 : (uint)_vFilterFiles.size() - 1;
+	SetCur(_uCur);
+}
+
+bool Panel::FilterProcess(KeyInfo& tKeyInfo)
+{
+	if (!_bFilterMode) return false;
+
+	int key = (int)tKeyInfo;
+
+	// ESC: exit filter mode
+	if (tKeyInfo.sKeyName == "ESC")
+	{
+		FilterExit();
+		return true;
+	}
+
+	// Backspace: remove last char
+	if (tKeyInfo.sKeyName == "BS")
+	{
+		if (!_sFilterStr.empty())
+		{
+			_sFilterStr.erase(_sFilterStr.size() - 1, 1);
+			ApplyFilter();
+		}
+		return true;
+	}
+
+	// Printable ASCII: add to filter string
+	if (32 < key && key <= 126)
+	{
+		_sFilterStr += (char)key;
+		ApplyFilter();
+		return true;
+	}
+
+	// Arrow keys and other navigation: pass through (return false)
+	return false;
+}
+
+void Panel::FilterExit()
+{
+	_bFilterMode = false;
+	_sFilterStr.clear();
+	_vFilterFiles.clear();
+	_bChange = true;
+	// Ensure cursor is valid in full list
+	if (_uCur >= _vDirFiles.size() && !_vDirFiles.empty())
+		_uCur = (uint)_vDirFiles.size() - 1;
+	SetCur(_uCur);
+}
+
+
 /// @param	str		IN 찾을 파일 앞자리나 전체 파일명
 /// @param	d_index	OUT 찾은 파일 Index.
 /// @param  s_index IN 파일을 찾을 첫번째 인덱스
@@ -902,9 +999,10 @@ int Panel::GetSelection(Selection& tSelection)
 {
 	if (_uSelNum == 0)
 	{
-		if (_vDirFiles[_uCur]->sName != "..")
+		File* pCurFile = GetCurFile();
+		if (pCurFile && pCurFile->sName != "..")
 		{
-			tSelection.Add(_vDirFiles[_uCur]);
+			tSelection.Add(pCurFile);
 		}
 	}
 	else

--- a/panel/common/panel.cpp
+++ b/panel/common/panel.cpp
@@ -24,6 +24,7 @@
 #include "cmdshell.h"
 #include "mlslocale.h"
 #include "mlsdialog.h"
+#include <regex>
 
 using namespace MLSUTIL;
 using namespace MLS;
@@ -853,14 +854,34 @@ void Panel::ApplyFilter()
 	if (_sFilterStr.empty())
 	{
 		_vFilterFiles = _vDirFiles;
+		_bFilterRegexValid = true;
 	}
 	else
 	{
-		string sLower = Tolower(_sFilterStr);
+		// Try to compile the filter string as a case-insensitive regex
+		bool bRegexOk = true;
+		std::regex re;
+		try {
+			re = std::regex(_sFilterStr, std::regex::icase | std::regex::optimize);
+		} catch (std::regex_error&) {
+			bRegexOk = false;
+		}
+		_bFilterRegexValid = bRegexOk;
+
+		string sLower = Tolower(_sFilterStr); // fallback for invalid regex
 		for (int i = 0; i < (int)_vDirFiles.size(); i++)
 		{
 			File* pFile = _vDirFiles[i];
-			if (pFile->bDir || Tolower(pFile->sName).find(sLower) != string::npos)
+			bool bMatch = false;
+			if (pFile->bDir) {
+				bMatch = true;
+			} else if (bRegexOk) {
+				bMatch = std::regex_search(pFile->sName, re);
+			} else {
+				// Invalid regex: fall back to case-insensitive substring match
+				bMatch = Tolower(pFile->sName).find(sLower) != string::npos;
+			}
+			if (bMatch)
 				_vFilterFiles.push_back(pFile);
 		}
 	}
@@ -912,6 +933,7 @@ void Panel::FilterExit()
 	_bFilterMode = false;
 	_sFilterStr.clear();
 	_vFilterFiles.clear();
+	_bFilterRegexValid = true;
 	_bChange = true;
 	// Ensure cursor is valid in full list
 	if (_uCur >= _vDirFiles.size() && !_vDirFiles.empty())

--- a/panel/common/panel.cpp
+++ b/panel/common/panel.cpp
@@ -241,6 +241,7 @@ bool	Panel::Read(const string& sPathConst, bool bShowError)
 					MsgBox(_("Error"), _("remote disconnected."));
 
 				pReader = GetReader();
+				if (pReader == NULL) return false;
 				pReader->SetErrMsgShow(bShowError);
 				if (pReader->Read("~") == false) return false;
 			}
@@ -266,6 +267,7 @@ bool	Panel::Read(const string& sPathConst, bool bShowError)
 					MsgBox(_("Error"), _("remote disconnected."));
 
 				pReader = GetReader();
+				if (pReader == NULL) return false;
 				pReader->SetErrMsgShow(bShowError);
 				if (pReader->Read("~") == false) return false;
 			}

--- a/panel/common/panel.cpp
+++ b/panel/common/panel.cpp
@@ -47,6 +47,7 @@ void	Panel::Init()
 	_bFilterMode = false;
 	_sFilterStr.clear();
 	_vFilterFiles.clear();
+	_bFilterRegexValid = true;
 
 	_tMemFile.Clear();	
 	_vDirFiles.clear();
@@ -206,7 +207,7 @@ Reader*	Panel::GetReader(const string& sPathOrType)
 	return pReader;
 }
 
-bool	Panel::Read(const string& sPathConst)
+bool	Panel::Read(const string& sPathConst, bool bShowError)
 {
 	Reader*		pReader = NULL;
 	string		sPrevDir;
@@ -230,15 +231,17 @@ bool	Panel::Read(const string& sPathConst)
 			return false;
 		}
 
-		pReader->SetErrMsgShow(true);
+		pReader->SetErrMsgShow(bShowError);
 		string sPath2 = sPath.substr(idx+2);
 		if (!pReader->Read(sPath2))
 		{
 			if (pReader->GetConnected() == false)
 			{
-				MsgBox(_("Error"), _("remote disconnected."));
+				if (bShowError)
+					MsgBox(_("Error"), _("remote disconnected."));
 
 				pReader = GetReader();
+				pReader->SetErrMsgShow(bShowError);
 				if (pReader->Read("~") == false) return false;
 			}
 			else
@@ -254,14 +257,16 @@ bool	Panel::Read(const string& sPathConst)
 			return false;
 		}
 		
-		pReader->SetErrMsgShow(true);
+		pReader->SetErrMsgShow(bShowError);
 		if (!pReader->Read(sPath)) 
 		{
 			if (pReader->GetConnected() == false)
 			{
-				MsgBox(_("Error"), _("remote disconnected."));
+				if (bShowError)
+					MsgBox(_("Error"), _("remote disconnected."));
 
 				pReader = GetReader();
+				pReader->SetErrMsgShow(bShowError);
 				if (pReader->Read("~") == false) return false;
 			}
 			else

--- a/panel/common/panel.h
+++ b/panel/common/panel.h
@@ -104,6 +104,10 @@ public:
 	bool	_bSearch;	///< 검색 여부
 	int		_nSort;		///< 현재 소트 위치
 
+	bool	_bFilterMode;	///< 필터 모드 활성 여부
+	string	_sFilterStr;	///< 현재 필터 문자열
+	vector<File*> _vFilterFiles;  ///< 필터된 파일 목록
+
 	bool	_bDirSortAscend;///< 디렉토리 정렬 순서
 	bool	_bFileSortAscend;///<파일 정렬 순서
 
@@ -122,6 +126,8 @@ public:
 		_bShowHidden = false;
 		_nSortMethod = SORT_COLOR;
 
+		_bFilterMode = false;
+
 		PluginLoader(&_tCtlReader);
 	}
 
@@ -132,19 +138,21 @@ public:
 
 	File*		GetCurFile() 
 	{ 
-		uint n = _vDirFiles.size();
+		vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+		uint n = vFiles.size();
 		if (n > _uCur && n != 0)
-			return _vDirFiles[_uCur];
+			return vFiles[_uCur];
 		return NULL;
 	}
 
 	File*		GetNextFile()
 	{
-		uint n = _vDirFiles.size();
+		vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+		uint n = vFiles.size();
 		if (n > _uCur+1 && n != 0)
-			return _vDirFiles[_uCur+1];
+			return vFiles[_uCur+1];
 		if ( n >= _uCur+1 && n != 0)
-			return _vDirFiles[n-1];
+			return vFiles[n-1];
 		return NULL;
 	}
 
@@ -240,6 +248,11 @@ public:
 	}
 	
 	bool	SearchProcess(KeyInfo&	tKeyInfo);
+	bool	FilterProcess(KeyInfo&	tKeyInfo);
+	void	FilterExit();
+	void	ApplyFilter();
+	bool	IsFilterMode() const { return _bFilterMode; }
+	const string& GetFilterStr() const { return _sFilterStr; }
 	bool	SearchExactFile(const string & fileName, uint & fileIndex, bool bFullName = false) const;
 	bool	SearchMatchingFile(const string &str, uint & d_index, int s_index = 0);
 	bool	SetCurFileName(const string& sFileName);

--- a/panel/common/panel.h
+++ b/panel/common/panel.h
@@ -104,9 +104,10 @@ public:
 	bool	_bSearch;	///< 검색 여부
 	int		_nSort;		///< 현재 소트 위치
 
-	bool	_bFilterMode;	///< 필터 모드 활성 여부
-	string	_sFilterStr;	///< 현재 필터 문자열
-	vector<File*> _vFilterFiles;  ///< 필터된 파일 목록
+	bool	_bFilterMode;		///< 필터 모드 활성 여부
+	string	_sFilterStr;		///< 현재 필터 문자열
+	vector<File*> _vFilterFiles;	///< 필터된 파일 목록
+	bool	_bFilterRegexValid;	///< 현재 필터 패턴이 유효한 regex인지 여부
 
 	bool	_bDirSortAscend;///< 디렉토리 정렬 순서
 	bool	_bFileSortAscend;///<파일 정렬 순서
@@ -252,6 +253,7 @@ public:
 	void	FilterExit();
 	void	ApplyFilter();
 	bool	IsFilterMode() const { return _bFilterMode; }
+	bool	IsFilterRegexValid() const { return _bFilterRegexValid; }
 	const string& GetFilterStr() const { return _sFilterStr; }
 	bool	SearchExactFile(const string & fileName, uint & fileIndex, bool bFullName = false) const;
 	bool	SearchMatchingFile(const string &str, uint & d_index, int s_index = 0);

--- a/panel/common/panel.h
+++ b/panel/common/panel.h
@@ -212,7 +212,7 @@ public:
 
 	virtual void	ReadEnd() {}
 
-	bool	Read(const string& sPath);
+	bool	Read(const string& sPath, bool bShowError = true);
 	
 	void	Key_Left();
 	void	Key_Right();

--- a/panel/vfs/dirreader.cpp
+++ b/panel/vfs/dirreader.cpp
@@ -77,8 +77,11 @@ string	GetCurrentPath(void)
 	else
 	{
 		// 현재 디렉토리 읽기 오류면 home 디렉토리 지정
-		struct passwd *pw = getpwuid(getuid()); // getuid이냐 geteuid냐...;
-		sPath = sPath + pw->pw_dir + '/';
+		struct passwd *pw = getpwuid(getuid());
+		if (pw && pw->pw_dir)
+			sPath = string(pw->pw_dir) + '/';
+		else
+			sPath = "/";
 	}
 	return sPath;
 }

--- a/panel/vfs/samba/SMBReader.cpp
+++ b/panel/vfs/samba/SMBReader.cpp
@@ -65,7 +65,7 @@ static void	AuthDataFn(	const char * pServer,
 		return;
 	}
 
-	sprintf( pWorkgroup, "%s", sWorkGroup.c_str() );
+	snprintf( pWorkgroup, (size_t)maxLenWorkgroup, "%s", sWorkGroup.c_str() );
 
 	sMsg.clear();
 	sMsg.Append(_("Samba Connect Input Username - [%s - %s] [%s]"), pServer, pShare, pWorkgroup);
@@ -76,7 +76,7 @@ static void	AuthDataFn(	const char * pServer,
 		return;
 	}
 
-	sprintf( pUsername, "%s", sUser.c_str() );
+	snprintf( pUsername, (size_t)maxLenUsername, "%s", sUser.c_str() );
 
 	sMsg.clear();
 	sMsg.Append(_("Samba Connect Input Passwd - [%s - %s] [%s %s] "), 
@@ -87,7 +87,7 @@ static void	AuthDataFn(	const char * pServer,
 		return;
 	}
 	
-	sprintf( pPassword, "%s", sPasswd.c_str() );
+	snprintf( pPassword, (size_t)maxLenPassword, "%s", sPasswd.c_str() );
 }
 
 SMBReader::SMBReader()

--- a/sh/CMakeLists.txt
+++ b/sh/CMakeLists.txt
@@ -1,12 +1,12 @@
 if (UNIX)
     add_custom_command(OUTPUT linm.sh
-            COMMAND sed "s%@bindir@%${LINM_BINPATH}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm.sh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm.sh )
+            COMMAND sed "s%@bindir@%${__LINM_BINPATH__}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm.sh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm.sh )
     add_custom_command(OUTPUT linm.csh
-            COMMAND sed "s%@bindir@%${LINM_BINPATH}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm.csh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm.csh )
+            COMMAND sed "s%@bindir@%${__LINM_BINPATH__}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm.csh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm.csh )
     add_custom_command(OUTPUT linm_alias.sh
-            COMMAND sed "s%@bindir@%${LINM_BINPATH}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm_alias.sh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm_alias.sh )
+            COMMAND sed "s%@bindir@%${__LINM_BINPATH__}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm_alias.sh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm_alias.sh )
     add_custom_command(OUTPUT linm_alias.csh
-            COMMAND sed "s%@bindir@%${LINM_BINPATH}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm_alias.csh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm_alias.csh )
+            COMMAND sed "s%@bindir@%${__LINM_BINPATH__}%" ${CMAKE_CURRENT_SOURCE_DIR}/linm_alias.csh.in > ${CMAKE_CURRENT_BINARY_DIR}/linm_alias.csh )
 
     add_custom_command(OUTPUT default.cfg
             COMMAND sed "s%@LINM_VERSION@%${VERSION}%" ${CMAKE_CURRENT_SOURCE_DIR}/default.cfg.in > ${CMAKE_CURRENT_BINARY_DIR}/default.cfg )

--- a/sh/default.cfg.in
+++ b/sh/default.cfg.in
@@ -8,6 +8,9 @@ NoSplit_NextWindow = Off
 # console tansparency support
 Transparency = Off
 
+# Mouse support On/Off
+Mouse = On
+
 # sort (0=none 1=name 2=ext 3=size 4=time 5=color)
 Sort = 5
 

--- a/sh/keyset.cfg.in
+++ b/sh/keyset.cfg.in
@@ -139,7 +139,7 @@ Cmd_Help    = F1
 Cmd_Refresh = F5
 Cmd_Menu    = F12
 Cmd_ESC     = ESC
-Cmd_Quit    = Alt+X,Ctrl+Q
+Cmd_Quit    = Alt+X, Ctrl+D,Ctrl+Q
 
 # Linm Panel key
 [Command_Panel]
@@ -156,7 +156,7 @@ Cmd_ExtEditor = F4
 Cmd_Copy    = Alt+C
 Cmd_Move    = Alt+M
 Cmd_Mkdir   = F7
-Cmd_Remove  = F8, Ctrl+D, Alt+D
+Cmd_Remove  = F8, Alt+D
 Cmd_SizeInfo= F9
 Cmd_MCD     = F10
 Cmd_QCD     = F11
@@ -178,6 +178,7 @@ Cmd_BoxCodeChange = Alt+L
 Cmd_LangChange = Ctrl+L
 Cmd_HiddenFileView = Alt+Z
 Cmd_FileOwnerView = Alt+O
+Cmd_FilterMode = Alt+F
 Cmd_SortChange = Alt+S
 Cmd_SortAscDescend = Alt+A
 Cmd_ColumnAuto = Alt+0
@@ -229,7 +230,7 @@ Cmd_Scan    = F4
 
 Cmd_Move    = F6
 Cmd_Mkdir   = F7
-Cmd_Remove  = F8, Ctrl+D, Alt+D
+Cmd_Remove  = F8, Alt+D
 Cmd_SizeInfo = F9
 Cmd_MountList  = F10,Ctrl+F
 Cmd_NextWindow = Ctrl+E,TAB
@@ -279,57 +280,101 @@ Cmd_ESC = _("Console View & Ftp Close")
 Cmd_Refresh = _("Refresh")
 
 [Help_Panel]
-Cmd_Rename = _("Rename")
-Cmd_Editor = _("Editor")
-Cmd_ExtEditor = _("VIM")
-Cmd_Move = _("Move")
-Cmd_Mkdir = _("Mkdir")
-Cmd_Remove = _("Remove")
-Cmd_SizeInfo = _("SizeInfo")
-Cmd_MCD = _("MCD")
-Cmd_QCD = _("QCD")
+Group_FileOp    = "File Operations"
+Cmd_Copy        = _("Copy")
+Cmd_Move        = _("Move")
+Cmd_Remove      = _("Remove")
+Cmd_Rename      = _("Rename")
+Cmd_Extract     = _("Extract Archive")
+Cmd_Execute     = _("Execute File")
 
-Cmd_Select = _("File or Directory Select")
-Cmd_Quit = _("LinM Quit")
-Cmd_NextWindow = _("Next Window")
-Cmd_Split = _("Window Split")
-Cmd_Shell = _("Command Shell")
+Group_FileCreate = "File Creation"
+Cmd_Mkdir       = _("Mkdir")
+Cmd_NewFile     = _("New File (Editor)")
+Cmd_TouchFile   = _("Touch file")
 
-Cmd_ClipCopy = _("Copy files into clipboard.")
-Cmd_ClipCut = _("Cut files into clipboard.")
-Cmd_ClipPaste = _("Clipboard files current directory paste.")
-Cmd_ViewClip = _("Clipboard files view.")
-Cmd_MountList  = _("Mount List")
+Group_Navigate  = "Navigation"
+Cmd_GoParent    = _("Go Parent Directory")
+Cmd_GoRoot      = _("Go Root Directory")
+Cmd_GoHome      = _("Go Home Directory")
+Cmd_Back        = _("Go back directory")
+Cmd_Forward     = _("Go forward directory")
 
-Cmd_Back = _("Go back directory")
-Cmd_Forward = _("Go forward directory")
+Group_Select    = "Selection"
+Cmd_Select      = _("File or Directory Select")
+Cmd_SelectAll   = _("Select All")
+Cmd_SelectInvert = _("Select Invert")
 
-Cmd_NewFile = _("Editor new file")
-Cmd_TouchFile = _("Touch file")
-Cmd_Chmod = _("Chmod")
-Cmd_Chown = _("Chown")
-Cmd_Diff = _("Diff")
+Group_Windows   = "Windows"
+Cmd_Split       = _("Window Split")
+Cmd_SplitViewSync = _("Split View Sync")
+Cmd_NextWindow  = _("Next Window")
 
-Cmd_RemoteConnProps = _("Remote")
-Cmd_SyncDirectory = _("Sync Directory")
+Group_View      = "View"
+Cmd_HiddenFileView = _("Toggle Hidden File View")
+Cmd_FileOwnerView  = _("Toggle File Owner View")
+Cmd_BoxCodeChange  = _("Box Code Change")
+Cmd_LangChange     = _("Language Change")
+
+Group_Columns   = "Columns"
+Cmd_ColumnAuto  = _("Column Auto")
+Cmd_Column1     = _("1 Column View")
+Cmd_Column2     = _("2 Column View")
+Cmd_Column3     = _("3 Column View")
+Cmd_Column4     = _("4 Column View")
+
+Group_Filter    = "Filter & Sort"
+Cmd_FilterMode      = _("Filter files by name")
+Cmd_SortChange      = _("Change Sort Type")
+Cmd_SortAscDescend  = _("Toggle Sort Asc/Desc")
+
+Group_Clipboard = "Clipboard"
+Cmd_ClipCopy    = _("Copy files into clipboard.")
+Cmd_ClipCut     = _("Cut files into clipboard.")
+Cmd_ClipPaste   = _("Clipboard files current directory paste.")
+Cmd_ViewClip    = _("Clipboard files view.")
+
+Group_FileInfo  = "File Info"
+Cmd_SizeInfo    = _("SizeInfo")
+Cmd_Chmod       = _("Chmod")
+Cmd_Chown       = _("Chown")
+Cmd_Diff        = _("Diff")
+Cmd_FileFind    = _("Find File")
+
+Group_Remote    = "Remote"
+Cmd_RemoteConnect   = _("Remote Connect")
+Cmd_RemoteClose     = _("Remote Close")
+Cmd_RemoteConnProps = _("Remote Properties")
+
+Group_Tools     = "Tools"
+Cmd_Shell       = _("Command Shell")
+Cmd_MountList   = _("Mount List")
+Cmd_MCD         = _("MCD")
+Cmd_QCD         = _("QCD")
 Cmd_ConsoleMode = _("Console Mode (MC similar)")
+Cmd_SyncDirectory = _("Sync Directory")
+
+Group_Config    = "Configuration"
+Cmd_SettingChange = _("Configure")
+Cmd_Editor      = _("Editor")
+Cmd_ExtEditor   = _("VIM")
 
 [Help_Mcd]
 Cmd_Mcd_SubDirOneSearch = _("search subdirectory.")
 Cmd_Mcd_SubDirAllSearch = _("all search directory.")
 Cmd_Mcd_SubDirClear = _("subdirectory tree screen clean.")
 
-Cmd_ClipCopy = _("current directory into clipboard.")
-Cmd_ClipCut = _("cut current directory into clipboard.")
-Cmd_ClipPaste = _("clipboard directory is current directory paste.")
+Cmd_ClipCopy    = _("current directory into clipboard.")
+Cmd_ClipCut     = _("cut current directory into clipboard.")
+Cmd_ClipPaste   = _("clipboard directory is current directory paste.")
 
 Cmd_RemoteConnect = _("ftp/sftp connect")
 Cmd_RemoteClose = _("connect close")
 
-Cmd_Mkdir  = _("Mkdir")
-Cmd_Rename = _("Rename")
-Cmd_Remove = _("Remove")
-Cmd_Move   = _("Move")
+Cmd_Mkdir   = _("Mkdir")
+Cmd_Rename  = _("Rename")
+Cmd_Remove  = _("Remove")
+Cmd_Move    = _("Move")
 
 Cmd_NextWindow  = _("Next Window")
 Cmd_Split       = _("Split Window")

--- a/sh/linm.csh.in
+++ b/sh/linm.csh.in
@@ -1,4 +1,4 @@
-setenv MLS_PWD_FILE $HOME/.linm/path
+setenv MLS_PWD_FILE $HOME/.config/linm/path
 
 @bindir@/linm $@
 

--- a/sh/linm.sh.in
+++ b/sh/linm.sh.in
@@ -1,6 +1,6 @@
 # install configuration files if not exist
 
-MLS_PWD_FILE="${HOME}/.linm/path"
+MLS_PWD_FILE="${HOME}/.config/linm/path"
 
 @bindir@/linm $@
 

--- a/src/ncurses/cmd_common_imp.cpp
+++ b/src/ncurses/cmd_common_imp.cpp
@@ -52,73 +52,121 @@ void	CmdCommonImp::Help()
     vMsgData.push_back("");
 
 	vMsgData.push_back( _("File Panel Key List") );
+	vMsgData.push_back( "" );
 
-	map<TypeInfo*, string>::iterator i;
+	vector<pair<TypeInfo*, string>>::iterator i;
 
 	for (i = g_tKeyCfg._mapKeyHelp.begin(); i != g_tKeyCfg._mapKeyHelp.end(); ++i)
 	{
-		if ( i->first->eType == PANEL || i->first->eType == COMMON )
+		if ( i->first->eType != PANEL )
+			continue;
+
+		// Group_ prefix: display as section header
+		if ( i->first->sValue.size() > 6 && i->first->sValue.substr(0, 6) == "Group_" )
 		{
-			string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
+			vMsgData.push_back( "" );
+			sMsg.Printf("  [ %s ]", i->second.c_str());
+			vMsgData.push_back(sMsg.c_str());
+			continue;
+		}
 
-			if (sKeyName.size() > 1 )
-				if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
-					continue;
+		string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
 
-			if ( !sKeyName.empty() && sKeyName != i->second)
-			{
-				sView = g_tKeyCfg.GetHelp( i->first->sValue, i->first->eType );
-				LOG("Key List :: [%s]", sView.c_str());
-				
-				sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
-				vMsgData.push_back(sMsg.c_str());
-			}
+		if (sKeyName.size() > 1 )
+			if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
+				continue;
+
+		if ( !sKeyName.empty() && sKeyName != i->second)
+		{
+			sView = i->second;
+			sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
+			vMsgData.push_back(sMsg.c_str());
+		}
+	}
+
+	// Common commands (shared across all views)
+	vMsgData.push_back( "" );
+	vMsgData.push_back( _("Common Keys") );
+	vMsgData.push_back( "" );
+
+	for (i = g_tKeyCfg._mapKeyHelp.begin(); i != g_tKeyCfg._mapKeyHelp.end(); ++i)
+	{
+		if ( i->first->eType != COMMON )
+			continue;
+
+		string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
+
+		if (sKeyName.size() > 1 )
+			if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
+				continue;
+
+		if ( !sKeyName.empty() && sKeyName != i->second)
+		{
+			sView = i->second;
+			sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
+			vMsgData.push_back(sMsg.c_str());
 		}
 	}
 
 	vMsgData.push_back("");
 	vMsgData.push_back( _("LinM Change Directory Key List") );
+	vMsgData.push_back( "" );
 
 	for (i = g_tKeyCfg._mapKeyHelp.begin(); i != g_tKeyCfg._mapKeyHelp.end(); ++i)
 	{
-		if ( i->first->eType == MCD || i->first->eType == COMMON )
+		if ( i->first->eType != MCD )
+			continue;
+
+		if ( i->first->sValue.size() > 6 && i->first->sValue.substr(0, 6) == "Group_" )
 		{
-			string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
+			vMsgData.push_back( "" );
+			sMsg.Printf("  [ %s ]", i->second.c_str());
+			vMsgData.push_back(sMsg.c_str());
+			continue;
+		}
 
-			if (sKeyName.size() > 1 )
-				if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
-					continue;
+		string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
 
-			if ( !sKeyName.empty() && sKeyName != i->second)
-			{
-				sView = g_tKeyCfg.GetHelp( i->first->sValue, i->first->eType );	
+		if (sKeyName.size() > 1 )
+			if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
+				continue;
 
-				sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
-				vMsgData.push_back(sMsg.c_str());
-			}
+		if ( !sKeyName.empty() && sKeyName != i->second)
+		{
+			sView = i->second;
+			sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
+			vMsgData.push_back(sMsg.c_str());
 		}
 	}
 
 	vMsgData.push_back("");
 	vMsgData.push_back( _("Simple Editor Key List") );
+	vMsgData.push_back( "" );
 
 	for (i = g_tKeyCfg._mapKeyHelp.begin(); i != g_tKeyCfg._mapKeyHelp.end(); ++i)
 	{
-		if ( i->first->eType == EDITOR || i->first->eType == COMMON )
+		if ( i->first->eType != EDITOR )
+			continue;
+
+		if ( i->first->sValue.size() > 6 && i->first->sValue.substr(0, 6) == "Group_" )
 		{
-			string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
+			vMsgData.push_back( "" );
+			sMsg.Printf("  [ %s ]", i->second.c_str());
+			vMsgData.push_back(sMsg.c_str());
+			continue;
+		}
 
-			if (sKeyName.size() > 1 )
-				if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
-					continue;
+		string sKeyName = g_tKeyCfg.CmdToKeyName( i->first->sValue, i->first->eType );
 
-			if ( !sKeyName.empty() && sKeyName != i->second)
-			{
-				sView = g_tKeyCfg.GetHelp( i->first->sValue, i->first->eType );
+		if (sKeyName.size() > 1 )
+			if ( sKeyName[0] == 'F' && (sKeyName[1] > '0' && sKeyName[1] <= '9'))
+				continue;
 
-				sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
-				vMsgData.push_back(sMsg.c_str());
-			}
+		if ( !sKeyName.empty() && sKeyName != i->second)
+		{
+			sView = i->second;
+			sMsg.Printf("    %-10s : %s", sKeyName.c_str(), _(sView.c_str()));
+			vMsgData.push_back(sMsg.c_str());
 		}
 	}
 

--- a/src/ncurses/cmd_editor_imp.cpp
+++ b/src/ncurses/cmd_editor_imp.cpp
@@ -121,8 +121,8 @@ void CmdEditorImp::Quit()
 {
 	if ( _pEditor->_bFullScreen )
 	{
-		MouseInit();
-		_pEditor->_bMouseMode = true;
+		if (!g_bNoMouse) MouseInit();
+		_pEditor->_bMouseMode = !g_bNoMouse;
 	}
 
 	if (_pEditor->Quit() == true)
@@ -316,7 +316,7 @@ void	CmdEditorImp::MouseUse()
 	{
 		_pEditor->_bMouseMode = !_pEditor->_bMouseMode;
 	
-		if ( _pEditor->_bMouseMode )
+		if ( _pEditor->_bMouseMode && !g_bNoMouse )
 			MouseInit();
 		else
 			MouseDestroy();

--- a/src/ncurses/cmd_mcd_imp.cpp
+++ b/src/ncurses/cmd_mcd_imp.cpp
@@ -767,7 +767,7 @@ void	CmdMcdImp::McdSave()
 		string sSaveName = 	g_tCfg.GetValue("Static", "CfgHome") + "McdDirSave/" +
 							 sPath;
 
-		// make 'McdDirSave' directory in '~/.linm'. and saved the MCD tree information.
+		// make 'McdDirSave' directory in '~/.config/linm'. and saved the MCD tree information.
 		mkdir((g_tCfg.GetValue("Static", "CfgHome") + "McdDirSave").c_str(), 0755);
 		
 		_pMcd->Save( sSaveName.c_str() );

--- a/src/ncurses/cmd_panel_imp.cpp
+++ b/src/ncurses/cmd_panel_imp.cpp
@@ -1189,6 +1189,19 @@ void CmdPanelImp::SortColor()
 	_pPanel->Sort();
 }
 
+void CmdPanelImp::FilterMode()
+{
+	if (_pPanel->IsFilterMode())
+		_pPanel->FilterExit();
+	else
+	{
+		_pPanel->_bFilterMode = true;
+		_pPanel->ApplyFilter();
+	}
+	_pPanel->_bChange = true;
+	g_tMainFrame.Refresh();
+}
+
 void CmdPanelImp::ColumnAuto() 
 { 
 	_pPanel->SetViewColumn(0);

--- a/src/ncurses/cmd_panel_imp.cpp
+++ b/src/ncurses/cmd_panel_imp.cpp
@@ -11,9 +11,21 @@
 #include "mainframe_view.h"
 #include "subshell.h"
 #include <fcntl.h>
+#include <sys/stat.h>
 
 using namespace MLS;
 using namespace MLSUTIL;
+
+/// @brief Wrap a filesystem path in single quotes for safe use in shell commands.
+static string ShellQuotePath(const string& path) {
+    string result = "'";
+    for (char c : path) {
+        if (c == '\'') result += "'\\''";
+        else result += c;
+    }
+    result += "'";
+    return result;
+}
 
 void CmdPanelImp::UpdateConfig()
 {
@@ -900,7 +912,7 @@ void	CmdPanelImp::CopyPaste()
 
 		if (g_tCfg.GetValue("Static", "TmpCopyDir") != "")
 		{
-			string sTmpDel = "rm -rf " + g_tCfg.GetValue("Static", "TmpCopyDir") + "*";
+			string sTmpDel = "rm -rf " + ShellQuotePath(g_tCfg.GetValue("Static", "TmpCopyDir")) + "*";
 			system( sTmpDel.c_str() );
 		}
 
@@ -1006,7 +1018,7 @@ void 	CmdPanelImp::CutPaste()
 
 		if (g_tCfg.GetValue("Static", "TmpCopyDir") != "")
 		{
-			string sTmpDel = "rm -rf " + g_tCfg.GetValue("Static", "TmpCopyDir") + "*";
+			string sTmpDel = "rm -rf " + ShellQuotePath(g_tCfg.GetValue("Static", "TmpCopyDir")) + "*";
 			system( sTmpDel.c_str() );
 		}
 
@@ -1389,8 +1401,15 @@ void	CmdPanelImp::TouchFile()
 	else
 		sFilename = g_tCfg.GetValue("Static", "TmpDir") + sFilename;
 
-	sFilename = "touch " + sFilename;
-	system( sFilename.c_str() );
+	// Use creat() syscall instead of system("touch ...") to avoid shell injection
+	int fd = open(sFilename.c_str(), O_CREAT | O_WRONLY | O_NOCTTY, 0644);
+	if (fd >= 0) {
+		close(fd);
+	} else {
+		// fallback for non-local paths (e.g. TmpDir on VFS)
+		string sCmd = "touch " + ShellQuotePath(sFilename);
+		system( sCmd.c_str() );
+	}
 	Refresh();
 }
 

--- a/src/ncurses/cmd_panel_imp.h
+++ b/src/ncurses/cmd_panel_imp.h
@@ -149,6 +149,9 @@ namespace MLS {
 
         void SortColor();
 
+        // filter
+        void FilterMode();
+
         void ColumnAuto();
 
         void Column1();

--- a/src/ncurses/cmd_settingchg.cpp
+++ b/src/ncurses/cmd_settingchg.cpp
@@ -52,6 +52,9 @@ void CmdPanelImp::SettingChange() {
     tOBJ.push_back(ConfigOBJ("Transparency", _("console tansparency"),
                              g_tCfg.GetValue("Default", "Transparency", "Off"),
                              CHECKBOX));
+    tOBJ.push_back(ConfigOBJ("Mouse", _("mouse support"),
+                             g_tCfg.GetValue("Default", "Mouse", "On"),
+                             CHECKBOX));
     tOBJ.push_back(ConfigOBJ("NoSplit_NextWindow", _("always enable change to next window"),
                              g_tCfg.GetValue("Default", "NoSplit_NextWindow", "Off"),
                              CHECKBOX));

--- a/src/ncurses/command.cpp
+++ b/src/ncurses/command.cpp
@@ -101,6 +101,7 @@ void	Command::Init()
 
 	_mapPanelFunc[new TypeInfo( PANEL, "SortChange")] 	= &CmdPanelImp::SortChange;
 	_mapPanelFunc[new TypeInfo( PANEL, "SortAscDescend")] = &CmdPanelImp::SortAscDescend;
+	_mapPanelFunc[new TypeInfo( PANEL, "FilterMode")]	= &CmdPanelImp::FilterMode;
 	_mapPanelFunc[new TypeInfo( PANEL, "ColumnAuto")]	= &CmdPanelImp::ColumnAuto;
 	_mapPanelFunc[new TypeInfo( PANEL, "Column1")]		= &CmdPanelImp::Column1;
 	_mapPanelFunc[new TypeInfo( PANEL, "Column2")]		= &CmdPanelImp::Column2;

--- a/src/ncurses/dialog/dialog_form.cpp
+++ b/src/ncurses/dialog/dialog_form.cpp
@@ -133,13 +133,16 @@ void	Form::Show()
 	{
 		LOG("new win");
 	
-		_pWin = newwin(y, x, height, width);
+		_pWin = newwin(height, width, y, x);
 
 		if (_pWin == NULL)
 			_pWin = newwin(0, 0, 0, 0);
 		
 		if (_pWin == NULL)
 			LOG("_pWin is NULL !!!!");
+
+		if (_pWin != NULL)
+			keypad(_pWin, TRUE);
 
 		LOG("new win end");
 	}
@@ -186,7 +189,7 @@ void	Form::Do()
 	{
 		Show();
 
-		tKeyInfo = tKeyReader.Read();
+		tKeyInfo = tKeyReader.Read(_pWin);
 
 		switch((int)tKeyInfo)
 		{

--- a/src/ncurses/dialog/drawset.cpp
+++ b/src/ncurses/dialog/drawset.cpp
@@ -37,6 +37,7 @@ chtype BTEE=ACS_BTEE;			///< Botton tree char.
 chtype TTEE=ACS_TTEE;			///< Bottom tree char.
 
 LINECODE	e_nBoxLineCode = AUTOLINE;	///< BOX LINE MODE
+bool		g_bNoMouse = false;			///< Ignore mouse input when true
 
 static Curses_Dialog*		s_pDialog = NULL;
 static Curses_Progress*		s_pProgressBox = NULL;

--- a/src/ncurses/dialog/drawset.h
+++ b/src/ncurses/dialog/drawset.h
@@ -48,6 +48,7 @@ extern chtype TTEE;
 enum LINECODE { AUTOLINE, CHARLINE, ACSLINE };
 
 extern LINECODE e_nBoxLineCode;
+extern bool g_bNoMouse;
 
 ///	\brief	color, attribute setting function with font color.
 ///	\param	font	font color

--- a/src/ncurses/main_ncurces.cpp
+++ b/src/ncurses/main_ncurces.cpp
@@ -39,6 +39,17 @@
 using namespace MLSUTIL;
 using namespace MLS;
 
+/// @brief Wrap a filesystem path in single quotes for safe use in shell commands.
+static string ShellQuotePath(const string& path) {
+    string result = "'";
+    for (char c : path) {
+        if (c == '\'') result += "'\\''";
+        else result += c;
+    }
+    result += "'";
+    return result;
+}
+
 namespace { // first default setting
 
 bool		_bMcdExe  = false;	    ///< Is execute MCD
@@ -139,7 +150,7 @@ bool Initialize()
 #endif
 				if (cfgfile == sCfgDefaultPath)
 				{
-					string sCmd = "cp " + sCfgDefaultPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
+					string sCmd = "cp " + ShellQuotePath(sCfgDefaultPath) + " " + ShellQuotePath(g_tCfg.GetValue("Static", "Home") + ".config/linm/");
 					system(sCmd.c_str());
 				}
 				break;
@@ -182,7 +193,7 @@ bool Initialize()
 #endif
 				if (colfile == sCfgColorPath)
 				{
-					string sCmd = "cp " + sCfgColorPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
+					string sCmd = "cp " + ShellQuotePath(sCfgColorPath) + " " + ShellQuotePath(g_tCfg.GetValue("Static", "Home") + ".config/linm/");
 					system(sCmd.c_str());
 				}
 				break;
@@ -239,7 +250,7 @@ bool	Load_KeyFile()
 #endif
 				if (keyfile == sKeyCfgPath)
 				{
-					string sCmd = "cp " + sKeyCfgPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
+					string sCmd = "cp " + ShellQuotePath(sKeyCfgPath) + " " + ShellQuotePath(g_tCfg.GetValue("Static", "Home") + ".config/linm/");
 					system(sCmd.c_str());
 				}
 				break;
@@ -284,7 +295,7 @@ bool	Load_KeyFile()
 #endif
 				if (syntexFile == sCfgSyntaxExtPath)
 				{
-					string sCmd = "cp " + sCfgSyntaxExtPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
+					string sCmd = "cp " + ShellQuotePath(sCfgSyntaxExtPath) + " " + ShellQuotePath(g_tCfg.GetValue("Static", "Home") + ".config/linm/");
 					system(sCmd.c_str());
 				}
 				break;

--- a/src/ncurses/main_ncurces.cpp
+++ b/src/ncurses/main_ncurces.cpp
@@ -106,13 +106,14 @@ bool Initialize()
 		}
 
 		// . config directory setting.
-		g_tCfg.SetStaticValue("CfgHome", g_tCfg.GetValue("Static", "Home") + ".linm/");
-		g_tCfg.SetStaticValue("TmpDir", g_tCfg.GetValue("Static", "Home") + ".linm/linm_tmpdir/");
-		g_tCfg.SetStaticValue("TmpCopyDir", g_tCfg.GetValue("Static", "Home") + ".linm/linm_copydir/");
+		g_tCfg.SetStaticValue("CfgHome", g_tCfg.GetValue("Static", "Home") + ".config/linm/");
+		g_tCfg.SetStaticValue("TmpDir", g_tCfg.GetValue("Static", "Home") + ".config/linm/linm_tmpdir/");
+		g_tCfg.SetStaticValue("TmpCopyDir", g_tCfg.GetValue("Static", "Home") + ".config/linm/linm_copydir/");
 		g_tColorCfg.Init();
 		
-		// make '.linm' in the home directory. It's need for save the mcd tree information.
-		mkdir((g_tCfg.GetValue("Static", "Home") + ".linm").c_str(), 0755);
+		// make '.config/linm' in the home directory. It's need for save the mcd tree information.
+		mkdir((g_tCfg.GetValue("Static", "Home") + ".config").c_str(), 0755);
+		mkdir((g_tCfg.GetValue("Static", "Home") + ".config/linm").c_str(), 0755);
 		// tmp directory required to view the files.
 		mkdir((g_tCfg.GetValue("Static", "TmpDir")).c_str(), 0777);		
 		// tmp directory required to copy the files.
@@ -138,7 +139,7 @@ bool Initialize()
 #endif
 				if (cfgfile == sCfgDefaultPath)
 				{
-					string sCmd = "cp " + sCfgDefaultPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sCfgDefaultPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				break;
@@ -181,7 +182,7 @@ bool Initialize()
 #endif
 				if (colfile == sCfgColorPath)
 				{
-					string sCmd = "cp " + sCfgColorPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sCfgColorPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				break;
@@ -238,7 +239,7 @@ bool	Load_KeyFile()
 #endif
 				if (keyfile == sKeyCfgPath)
 				{
-					string sCmd = "cp " + sKeyCfgPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sKeyCfgPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				break;
@@ -283,7 +284,7 @@ bool	Load_KeyFile()
 #endif
 				if (syntexFile == sCfgSyntaxExtPath)
 				{
-					string sCmd = "cp " + sCfgSyntaxExtPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sCfgSyntaxExtPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				break;
@@ -333,7 +334,8 @@ void PrintHelp(void)
 		"\t --col=FILE   : 컬러셋 파일 지정\n"
 		"\t --key=FILE   : 키 파일 지정\n"
 		"\t --noline     : 선형태를 -,|,+ 로 바꿈\n"
-		"\t --mcd        : 바로 MCD 실행 \n";
+		"\t --mcd        : 바로 MCD 실행 \n"
+		"\t --nomouse    : 마우스 입력 무시 (환경변수 LINM_NO_MOUSE=1 도 사용 가능)\n";
 
 	const char *sStr_En =
 		"LinM is a clone of Mdir, the famous file manager from the MS-DOS age. \n"
@@ -351,7 +353,8 @@ void PrintHelp(void)
 		"\t --col=FILE   : load colorset file\n"
 		"\t --key=FILE   : load keybind file\n"
 		"\t --noline     : change box code to ascii character(-,|,+)\n"
-		"\t --mcd        : excute Mcd \n";
+		"\t --mcd        : excute Mcd \n"
+		"\t --nomouse    : ignore mouse input (env var LINM_NO_MOUSE=1 also works)\n";
 
 	cout << ChgEngKor(sStr_En, sStr_Ko) << endl;
 }
@@ -371,8 +374,12 @@ void OptionProc(int	argc, char * const	argv[])
 		{ "cfg",    required_argument, NULL,   'c' },
 		{ "col",    required_argument, NULL,   's' },
 		{ "key",    required_argument, NULL,   'k' },
+		{ "nomouse", no_argument,       NULL,   'M' },
 		{ NULL,		0,				   NULL,	0  }
 	};
+
+	if ( getenv("LINM_NO_MOUSE") )
+		g_bNoMouse = true;
 
 	if ( getenv("TERM") )
 	{
@@ -406,7 +413,7 @@ void OptionProc(int	argc, char * const	argv[])
 	string	sLogFile = "/dev/null";
 	cout << "LinM "<< VERSION << ", user-friendly graphic shell, 2007" <<  endl << endl;
 
-	while((opt = getopt_long(argc, argv, "hnmldcsk:", longopts, NULL)) != -1)
+	while((opt = getopt_long(argc, argv, "hnmldcsk:M", longopts, NULL)) != -1)
 	{
 		switch(opt)
 		{
@@ -433,6 +440,10 @@ void OptionProc(int	argc, char * const	argv[])
 
 		case 'm':		// mcd
 			_bMcdExe = true;
+			break;
+
+		case 'M':		// nomouse
+			g_bNoMouse = true;
 			break;
 
 		case 'c':       // configure file
@@ -481,25 +492,53 @@ void OptionProc(int	argc, char * const	argv[])
 	}
 }
 
-void	CopyConfFiles()
+void	CopyConfFiles(char *argv[])
 {
-    if (g_tCfg.getVersion() != VERSION)
+    bool bNeedMerge = (g_tCfg.getVersion()          != VERSION) ||
+                      (g_tKeyCfg.getVersion()        != VERSION) ||
+                      (g_tColorCfg.getVersion()      != VERSION) ||
+                      (g_tSyntaxExtCfg.getVersion()  != VERSION);
+
+    if (bNeedMerge)
     {
-        bool bYN = YNBox(_("Error"), 
-						_("configuration files are not compatible. configuration files copy ?"), 
-						true);
+        string sysPath = string(__LINM_CFGPATH__);
 
-        if (bYN == true)
-        {
-            system(	"mkdir ~/.linm/back 2> /dev/null > /dev/null; "
-					"cp ~/linm/* ~/.linm/back 2> /dev/null > /dev/null; "
-					"cp " __LINM_CFGPATH__ "/* ~/.linm 2> /dev/null > /dev/null");
+        // Backup existing user config files before any changes
+        system("mkdir -p ~/.config/linm/back/ 2>/dev/null >/dev/null; "
+               "cp ~/.config/linm/*.cfg ~/.config/linm/back/ 2>/dev/null >/dev/null");
 
-            g_tCfg.Load((g_tCfg.GetValue("Static", "CfgHome") + "default.cfg").c_str());
-            g_tColorCfg.Load((g_tCfg.GetValue("Static", "CfgHome") + "colorset.cfg").c_str());
-            g_tKeyCfg.Load((g_tCfg.GetValue("Static", "CfgHome") + "keyset.cfg").c_str());
-            g_tKeyCfg.Load((g_tCfg.GetValue("Static", "CfgHome") + "syntexset.cfg").c_str());
+        // Merge keys present in the system defaults but absent in the user's configs.
+        // Each config file is merged independently; existing user settings are never overwritten.
+        if (g_tCfg.getVersion() != VERSION) {
+            g_tCfg.MergeFromFile(sysPath + "/default.cfg");
+            g_tCfg.setVersion(VERSION);
+            g_tCfg.Save();
         }
+
+        if (g_tKeyCfg.getVersion() != VERSION) {
+            g_tKeyCfg.MergeFromFile(sysPath + "/keyset.cfg");
+            g_tKeyCfg.setVersion(VERSION);
+            g_tKeyCfg.Save();
+        }
+
+        if (g_tColorCfg.getVersion() != VERSION) {
+            g_tColorCfg.MergeFromFile(sysPath + "/colorset.cfg");
+            g_tColorCfg.setVersion(VERSION);
+            g_tColorCfg.Save();
+        }
+
+        if (g_tSyntaxExtCfg.getVersion() != VERSION) {
+            g_tSyntaxExtCfg.MergeFromFile(sysPath + "/syntexset.cfg");
+            g_tSyntaxExtCfg.setVersion(VERSION);
+            g_tSyntaxExtCfg.Save();
+        }
+
+        MsgBox(_("Info"), _("Configuration updated to version " VERSION ". Restarting..."));
+
+        // Restart the process so that all merged settings take effect cleanly.
+        CursesDestroy();
+        execvp(argv[0], argv);
+        // execvp only returns on failure; fall through to continue with partially-applied config.
     }
 }
 
@@ -510,13 +549,17 @@ int main(int argc, char *argv[])
 	if (Initialize() == false) return SUCCESS;
 	if (Load_KeyFile() == false) return SUCCESS;
 
+	// Config file value applied only if not already disabled by CLI/env
+	if (!g_bNoMouse)
+		g_bNoMouse = !g_tCfg.GetBool("Default", "Mouse", true);
+
 	Signal_Blocking();
 
 	// terminal title change.
 	printf("%c]0;LinM %s%c", '\033', VERSION, '\007');
 
 	CursesInit( g_tCfg.GetBool("Default", "Transparency", false ) );
-	MouseInit();
+	if (!g_bNoMouse) MouseInit();
 
 	if ( g_SubShell.CheckSid() == ERROR )
 	{
@@ -527,7 +570,7 @@ int main(int argc, char *argv[])
 
 	try
 	{
-		CopyConfFiles();
+		CopyConfFiles(argv);
 				
 		g_tMainFrame.SetTitleChange( _bTitleChange );
 

--- a/src/ncurses/main_ncurces.cpp
+++ b/src/ncurses/main_ncurces.cpp
@@ -74,24 +74,31 @@ bool Initialize()
 	
 	string	sCwd;
 	char*	cwd = getcwd(NULL, 0);
-	if (cwd == NULL)
+	if (cwd != NULL && access(cwd, R_OK | X_OK) != -1)
 	{
-		String sMsg;
-		sMsg.AppendBlank(60, "%s", strerror(errno));
-		cout << sMsg.c_str();
-		cout << errMsg << endl;
-		return false;
+		sCwd = cwd;
+		free(cwd);
 	}
-	if (access(cwd, R_OK | X_OK) == -1)
+	else
 	{
-		String sMsg;
-		sMsg.AppendBlank(60, "%s", strerror(errno));
-		cout << sMsg.c_str();
-		cout << errMsg << endl;
-		return false;
+		if (cwd)
+			free(cwd);
+
+		struct passwd *pw = getpwuid(getuid());
+		if (pw && pw->pw_dir && access(pw->pw_dir, R_OK | X_OK) != -1)
+			sCwd = pw->pw_dir;
+		else
+			sCwd = "/";
+
+		if (chdir(sCwd.c_str()) == -1)
+		{
+			String sMsg;
+			sMsg.AppendBlank(60, "%s", strerror(errno));
+			cout << sMsg.c_str();
+			cout << errMsg << endl;
+			return false;
+		}
 	}
-	sCwd = cwd;
-	free(cwd);
 
 	Set_Locale(_nLangSet); 	// Locale setting.
 	

--- a/src/ncurses/mainframe.cpp
+++ b/src/ncurses/mainframe.cpp
@@ -565,7 +565,7 @@ void MainFrame::Execute(KeyInfo &tKeyInfo) {
 
     if (_bShell) curs_set(1);
 
-#ifdef __DEBUGMODE__
+#if __DEBUGMODE__
     if (nRt == ERROR) {
         String sMsg(_("configure command not found.."));
         sMsg.Append(_("[%s]"), sCmd.c_str());

--- a/src/ncurses/mainframe.cpp
+++ b/src/ncurses/mainframe.cpp
@@ -56,7 +56,7 @@ void TitleChange(const string &sPath, bool bHostNameShow) {
         if (pw)
             sLogin = pw->pw_name;
     } else
-        sprintf(cHostName, "localhost");
+        snprintf(cHostName, sizeof(cHostName), "localhost");
 
     if (strlen(cHostName) == 0 || sLogin.size() == 0 || !bHostNameShow) {
         printf("%c]0;LinM %s - %s%c", '\033', VERSION, sStr.c_str(), '\007');

--- a/src/ncurses/mainframe.cpp
+++ b/src/ncurses/mainframe.cpp
@@ -119,7 +119,8 @@ void MainFrame::Init() {
             exit(1);
     if (!_tPanel[1].Read(_sLastPath))
         if (!_tPanel[1].Read("~"))
-            exit(1);
+            if (!_tPanel[1].Read("."))
+                exit(1);
 
     _tMcd[0]._bFocus = _tPanel[0]._bFocus = _nActive ? false : true;
     _tMcd[1]._bFocus = _tPanel[1]._bFocus = _nActive ? true : false;
@@ -132,8 +133,10 @@ void MainFrame::Init() {
         _eViewType[1] = PANEL;
         _tMcd[0]._bFocus = true;
         _tPanel[1]._bFocus = true;
-        _tMcd[0].AddDirectory(_tPanel[1].GetReader()->GetPath());
-        _tMcd[0].SetCur(_tPanel[1].GetReader()->GetPath());
+        if (_tPanel[1].GetReader()) {
+            _tMcd[0].AddDirectory(_tPanel[1].GetReader()->GetPath());
+            _tMcd[0].SetCur(_tPanel[1].GetReader()->GetPath());
+        }
     }
     _tCommand.SetPanel(&_tPanel[_nActive]);
     _tCommand.SetMcd(&_tMcd[_nActive]);
@@ -501,6 +504,14 @@ void MainFrame::Execute(KeyInfo &tKeyInfo) {
                 bSearch = false;
     }
 
+    // Filter mode: consume key in FilterProcess first (suppresses incremental search)
+    if (_eViewType[_nActive] == PANEL && _tPanel[_nActive].IsFilterMode()) {
+        if (_tPanel[_nActive].FilterProcess(tKeyInfo)) {
+            _tPanel[_nActive]._bChange = true;
+            return;
+        }
+    }
+
     if (bSearch) {
         switch (_eViewType[_nActive]) {
             case PANEL:
@@ -684,8 +695,8 @@ void MainFrame::Split() {
 
     if (_tEditor[_nActive]._bFocus) {
         if (_bSplit) {
-            MouseInit();
-            _tEditor[_nActive]._bMouseMode = true;
+            if (!g_bNoMouse) MouseInit();
+            _tEditor[_nActive]._bMouseMode = !g_bNoMouse;
         } else {
             MouseDestroy();
             _tEditor[_nActive]._bMouseMode = false;

--- a/src/ncurses/mainframe.cpp
+++ b/src/ncurses/mainframe.cpp
@@ -24,6 +24,21 @@
 using namespace MLSUTIL;
 using namespace MLS;
 
+namespace {
+bool ReadStartupPath(Panel& panel, const string* paths, size_t count, string* resolvedPath = NULL) {
+    for (size_t i = 0; i < count; ++i) {
+        if (paths[i].empty())
+            continue;
+        if (panel.Read(paths[i], false)) {
+            if (resolvedPath)
+                *resolvedPath = panel.GetPath();
+            return true;
+        }
+    }
+    return false;
+}
+}
+
 inline void SetPosition(Position *pPosition, Form *pForm, int y, int x, int height, int width) {
     pPosition->SetForm(pForm);
     pPosition->y = y;
@@ -114,13 +129,19 @@ void MainFrame::SaveConfig() {
 }
 
 void MainFrame::Init() {
-    if (!_tPanel[0].Read("."))
-        if (!_tPanel[0].Read("~"))
-            exit(1);
-    if (!_tPanel[1].Read(_sLastPath))
-        if (!_tPanel[1].Read("~"))
-            if (!_tPanel[1].Read("."))
-                exit(1);
+    string sPanel0Paths[] = {".", "~", "/"};
+    string sPanel1Paths[] = {_sLastPath, "~", ".", "/"};
+    string sResolvedLastPath;
+
+    if (!ReadStartupPath(_tPanel[0], sPanel0Paths, 3))
+        exit(1);
+    if (!ReadStartupPath(_tPanel[1], sPanel1Paths, 4, &sResolvedLastPath))
+        exit(1);
+    if (!sResolvedLastPath.empty() && sResolvedLastPath != _sLastPath) {
+        _sLastPath = sResolvedLastPath;
+        _Config.SetValue("User", "LastPath", _sLastPath, true);
+        _Config.Save();
+    }
 
     _tMcd[0]._bFocus = _tPanel[0]._bFocus = _nActive ? false : true;
     _tMcd[1]._bFocus = _tPanel[1]._bFocus = _nActive ? true : false;
@@ -805,4 +826,3 @@ void MainFrame::SyncDirectory() {
     }
     return;
 }
-

--- a/src/ncurses/ncurses_panel.cpp
+++ b/src/ncurses/ncurses_panel.cpp
@@ -260,7 +260,7 @@ void	Dialog_FileBox::Draw()
 // _nCol, _nRow getsize 
 void	NCurses_Panel::InitDraw()
 {
-	int nSize = _vDirFiles.size();
+	int nSize = _bFilterMode ? (int)_vFilterFiles.size() : (int)_vDirFiles.size();
 	const int nMaxlen = 12;
 
 	// Auto Column Mode.
@@ -349,7 +349,9 @@ void	NCurses_Panel::LineDraw()
 
 	// Find Section.
 	setcol(g_tColorCfg._DefaultColor);
-	if (!_sStrSearch.empty())
+	if (_bFilterMode)
+		mvwprintw(_pWin, 0, width-24, "[F:%-20s]", _sFilterStr.c_str());
+	else if (!_sStrSearch.empty())
 		mvwprintw(_pWin, 0, width-22, "[%-20s]", _sStrSearch.c_str());
 	//mvwprintw(_pWin, 0, 0, "[%d %d %d %d %d]", _uCur, _nPage, _nBefPage, _nCol, _nRow);
 
@@ -364,6 +366,9 @@ void NCurses_Panel::Draw()
 	Dialog_FileBox* pFileBox = NULL;
 	File*	pFile = NULL;
 
+	// Use filtered list when filter mode is active
+	vector<File*>& vFiles = _bFilterMode ? _vFilterFiles : _vDirFiles;
+
 	if ( _nCol != 0 && _nRow != 0 )
 		_nPage = _uCur / (_nCol * _nRow);
 
@@ -376,9 +381,9 @@ void NCurses_Panel::Draw()
 		for (int nRow = 1; nRow < _nRow+1; nRow++)
 		{
 			pFileBox = _vDrawFileList[nNum];
-			if (nCur < (int)_vDirFiles.size())
+			if (nCur < (int)vFiles.size())
 			{
-				pFile = _vDirFiles[nCur];
+				pFile = vFiles[nCur];
 				if (_bChange)
 				{
 					pFileBox->SetForm((Form*)this);

--- a/src/ncurses/ncurses_panel.cpp
+++ b/src/ncurses/ncurses_panel.cpp
@@ -350,7 +350,10 @@ void	NCurses_Panel::LineDraw()
 	// Find Section.
 	setcol(g_tColorCfg._DefaultColor);
 	if (_bFilterMode)
-		mvwprintw(_pWin, 0, width-24, "[F:%-20s]", _sFilterStr.c_str());
+	{
+		const char* prefix = _bFilterRegexValid ? "[F/RE:%-17s]" : "[F/?:%-18s]";
+		mvwprintw(_pWin, 0, width-24, prefix, _sFilterStr.c_str());
+	}
 	else if (!_sStrSearch.empty())
 		mvwprintw(_pWin, 0, width-22, "[%-20s]", _sStrSearch.c_str());
 	//mvwprintw(_pWin, 0, 0, "[%d %d %d %d %d]", _uCur, _nPage, _nBefPage, _nCol, _nRow);

--- a/src/ncurses/subshell.cpp
+++ b/src/ncurses/subshell.cpp
@@ -290,7 +290,7 @@ void	SubShell::InitSubShellChild(const string& sPtyName, const string& sDir)
 		setenv ("MC_SID", strSid.c_str(), 1 );	// Avoid conflict with MC(Midnight Commander).
     }
     
-	sInitFile = "~/.linm/bashrc";
+	sInitFile = "~/.config/linm/bashrc";
 	if (access (sInitFile.c_str(), R_OK) == -1)
 	    sInitFile = "~/.bashrc";
 	

--- a/src/qt/qtpanel/qtlinm_main.cpp
+++ b/src/qt/qtpanel/qtlinm_main.cpp
@@ -65,7 +65,7 @@ void fontSelect()
 }
 */
 
-#define 	__LINM_CFGPATH__		"~/.linm"
+#define 	__LINM_CFGPATH__		"~/.config/linm"
 
 namespace { // 처음 기본 세팅
 
@@ -118,12 +118,13 @@ bool Initialize()
 		}
 
 		// . config dir 지정
-		g_tCfg.SetStaticValue("CfgHome", g_tCfg.GetValue("Static", "Home") + ".linm/");
-		g_tCfg.SetStaticValue("TmpDir", g_tCfg.GetValue("Static", "Home") + ".linm/linm_tmpdir/");
+		g_tCfg.SetStaticValue("CfgHome", g_tCfg.GetValue("Static", "Home") + ".config/linm/");
+		g_tCfg.SetStaticValue("TmpDir", g_tCfg.GetValue("Static", "Home") + ".config/linm/linm_tmpdir/");
 		g_tColorCfg.Init();
 		
-		// 홈에 .linm를 만든다. mcd treeinfo를 저장하기 위해서도 필요
-		mkdir((g_tCfg.GetValue("Static", "Home") + ".linm").c_str(), 0755);
+		// 홈에 .config/linm를 만든다. mcd treeinfo를 저장하기 위해서도 필요
+		mkdir((g_tCfg.GetValue("Static", "Home") + ".config").c_str(), 0755);
+		mkdir((g_tCfg.GetValue("Static", "Home") + ".config/linm").c_str(), 0755);
 		// 파일 복사에 필요한 tmp 디렉토리.
 		mkdir((g_tCfg.GetValue("Static", "TmpDir")).c_str(), 0777);
 	}
@@ -148,7 +149,7 @@ bool Initialize()
 				/*
 				if (cfgfile == sCfgDefaultPath)
 				{
-					string sCmd = "cp " + sCfgDefaultPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sCfgDefaultPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				*/
@@ -193,7 +194,7 @@ bool Initialize()
 				/*
 				if (colfile == sCfgColorPath)
 				{
-					string sCmd = "cp " + sCfgColorPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sCfgColorPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				*/
@@ -270,7 +271,7 @@ bool	Load_KeyFile()
 #endif
 				if (keyfile == sKeyCfgPath)
 				{
-					string sCmd = "cp " + sKeyCfgPath + " " + g_tCfg.GetValue("Static", "Home") + ".linm";
+					string sCmd = "cp " + sKeyCfgPath + " " + g_tCfg.GetValue("Static", "Home") + ".config/linm/";
 					system(sCmd.c_str());
 				}
 				break;
@@ -336,7 +337,7 @@ int main( int argc, char ** argv )
 		
 		if (!Initialize())
 		{
-			QMessageBox::critical( NULL, QObject::tr("Error"), QObject::tr("config file not founed.(~/.linm/*.cfg") );
+			QMessageBox::critical( NULL, QObject::tr("Error"), QObject::tr("config file not founed.(~/.config/linm/*.cfg") );
 			return 0;
 		}
 


### PR DESCRIPTION
## Summary of Changes

This PR adds several new features and improvements developed in the fork:

### New Features

#### Alt+F — Real-time file name filter
- Press `Alt+F` to activate filter input in the active panel
- As you type, only files whose names contain the string are shown (directories always visible)
- Filter persists when navigating into subdirectories
- Press `ESC` or `Alt+F` again to clear

#### Alt+S — Sort mode popup
- Press `Alt+S` to open a popup menu for selecting sort mode on the fly
- Options: None / Name / Ext / Size / Time / Color

#### Mouse control options
- `--nomouse` / `-M` CLI flag to disable mouse input
- `LINM_NO_MOUSE` environment variable
- `Mouse = On/Off` setting in `default.cfg`

#### Ctrl+D reassigned to Quit only
- Removed `Ctrl+D` from `Cmd_Remove` (delete); it remains only in `Cmd_Quit`

### Improvements

#### Smart config merge on version upgrade
- Instead of a Yes/No dialog that either overwrites all settings or ignores new keys:
  - Automatically backs up `~/.config/linm/*.cfg` to `back/`
  - Merges only missing keys from system defaults (existing user settings preserved)
  - All 4 config files (`default`, `keyset`, `colorset`, `syntexset`) are checked independently
  - Restarts via `execvp` so all merged settings take effect immediately
- New method: `Configure::MergeFromFile()`

#### F1 Help reorganized
- Commands grouped into logical sections (navigation, file ops, view, filter/sort, etc.)
- Missing commands added; display order made consistent

### Documentation & Build
- `README.md` and `README.ko` rewritten: cmake build guide, Korean install guide
- `.gitignore` added for C++/CMake projects
- `ChangeLog` updated; version bumped to `0.9.3`